### PR TITLE
Renamed the previous and added two other bulkscan functions; added new features for additional covariates.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+    "julia.environmentPath": "/Users/FredYu/Documents/GitHub/BulkLMM.jl"
+}

--- a/src/BulkLMM.jl
+++ b/src/BulkLMM.jl
@@ -29,7 +29,7 @@ module BulkLMM
     export scan_perms_lite
 
     include("./bulkscan.jl");
-    export scan_lite_multivar
+    export bulkscan_trunk, bulkscan_grid, bulkscan_max
 
     include("./transform_helpers.jl");
     # export transform_rotation

--- a/src/BulkLMM.jl
+++ b/src/BulkLMM.jl
@@ -16,7 +16,9 @@ module BulkLMM
     # code for (wls) weighted least squares
     include("./wls.jl");
     export wls
+    export wls_multivar # multivariate version of WLS
     export LSEstimates
+    export LSEstimates_multivar # multivariate version of WLS results
 
     # code for rorateData and flmm
     include("./lmm.jl");
@@ -28,8 +30,10 @@ module BulkLMM
     # export scan_perms
     export scan_perms_lite
 
+    include("./bulkscan_helpers.jl");
+
     include("./bulkscan.jl");
-    export bulkscan_trunk, bulkscan_grid, bulkscan_max
+    export bulkscan_null, bulkscan_null_grid, bulkscan_alt_grid
 
     include("./transform_helpers.jl");
     # export transform_rotation

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -101,6 +101,19 @@ function bulkscan_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Floa
 
 end
 
+function bulkscan_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float64, 2}, 
+                       K::Array{Float64, 2}, grid_list::Array{Float64, 1})
+
+    m = size(Y, 2);
+    p = size(G, 2);
+
+    results_by_bin = gridscan_by_bin(Y, G, Covar, K, grid_list);
+    LOD_grid = reorder_results(results_by_bin.idxs_by_bin, results_by_bin.LODs_by_bin, m, p);
+
+    return LOD_grid
+
+end
+
 ###### Given the heritability (hsq), compute all LOD scores with performing LiteQTL once.
 
 ## Note: approximated method for scan_alt()

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -27,7 +27,7 @@ Calculates the LOD scores for all pairs of traits and markers, by a (multi-threa
 # Notes:
 
 """
-function bulkscan_trunk(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, nb::Int64; 
+function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, nb::Int64; 
                    nt_blas::Int64 = 1, prior_variance = 1.0, prior_sample_size = 0.0,
                    reml::Bool = false)
 
@@ -89,7 +89,7 @@ function bulkscan_trunk(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Flo
 
 end
 ### Modeling covariates version
-function bulkscan_trunk(Y::Array{Float64, 2}, G::Array{Float64, 2}, 
+function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2}, 
                         Covar::Array{Float64, 2}, K::Array{Float64, 2}, nb::Int64; 
     nt_blas::Int64 = 1, prior_variance = 1.0, prior_sample_size = 0.0,
     reml::Bool = false)
@@ -161,7 +161,7 @@ end
 ## a discrete grid of h2; results should be viewed as an approximation 
 ## of scan_null() results for each trait.
 ###########################################################
-function bulkscan_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, grid_list::Array{Float64, 1})
+function bulkscan_null_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, grid_list::Array{Float64, 1})
 
     m = size(Y, 2);
     p = size(G, 2);
@@ -173,7 +173,7 @@ function bulkscan_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Floa
 
 end
 
-function bulkscan_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float64, 2}, 
+function bulkscan_null_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float64, 2}, 
                        K::Array{Float64, 2}, grid_list::Array{Float64, 1})
 
     m = size(Y, 2);
@@ -193,7 +193,7 @@ end
 ## of scan_alt() results for each trait.
 ###########################################################
 """
-bulkscan_max(Y, G, K, hsq_list)
+bulkscan_alt_grid(Y, G, K, hsq_list)
 
 Calculates LOD scores for all pairs of traits and markers for each heritability in the supplied list, and returns the 
     maximal LOD scores for each pair among all calculated ones
@@ -215,7 +215,7 @@ Maximal LOD scores are taken independently for each pair of trait and marker; wh
     this is a shortcut of doing the exact scan_alt() independently for each trait and each marker.
 
 """
-function bulkscan_max(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, hsq_list::Array{Float64, 1})
+function bulkscan_alt_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, hsq_list::Array{Float64, 1})
 
     (Y0, X0, lambda0) = transform_rotation(Y, G, K);
 
@@ -232,7 +232,7 @@ function bulkscan_max(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float
 
 end
 
-function bulkscan_max(Y::Array{Float64, 2}, G::Array{Float64, 2}, 
+function bulkscan_alt_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, 
                       Covar::Array{Float64, 2}, K::Array{Float64, 2}, hsq_list::Array{Float64, 1})
 
     (Y0, X0, lambda0) = transform_rotation(Y, [Covar G], K);

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -27,7 +27,8 @@ Calculates the LOD scores for all pairs of traits and markers, by a (multi-threa
 # Notes:
 
 """
-function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, nb::Int64; 
+function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2};
+                   nb::Int64 = Threads.nthreads(), 
                    nt_blas::Int64 = 1, prior_variance = 1.0, prior_sample_size = 0.0,
                    reml::Bool = false)
 

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -4,13 +4,13 @@
 ###########################################################
 
 ###########################################################
-## (1) Trunking methods:
+## (1) Chunk methods:
 ## idea is to use multithreaded processes to run genome scans sequentially
 ## on traits that are inside a block that is a subset of total number of traits;
 ## results should be exact as given by running scan_null() on each trait.
 ###########################################################
 """
-bulkscan_trunk(Y, G, K, nb; reml = true)
+bulkscan_null(Y, G, K, nb; reml = true)
 
 Calculates the LOD scores for all pairs of traits and markers, by a (multi-threaded) loop over blocks of traits and the LiteQTL-type of approach
 
@@ -187,7 +187,7 @@ function bulkscan_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{
 end
 
 ###########################################################
-## (2) Grid + element-wise maximization approximation methods:
+## (3) Grid + element-wise maximization approximation methods:
 ## idea is to approximate the exact MLE/REML estimate of h2 (independently for each marker)
 ## using a discrete grid of h2; results should be viewed as an approximation 
 ## of scan_alt() results for each trait.
@@ -201,7 +201,7 @@ Calculates LOD scores for all pairs of traits and markers for each heritability 
 # Arguments
 - Y = 2d Array of Float; traits 
 - G = 2d Array of Float; genotype probabilities
-- K = 2d Array of Floatl kinship matrix
+- K = 2d Array of Float; kinship matrix
 - hsq_list = 1d array of Float; the list of heritabilities requested to choose from
 
 # Value

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -83,7 +83,7 @@ Will modify input matrix R; uses a multi-threaded loop.
 """
 function tR2LOD!(R::Array{Float64, 2}, n::Int64)
     
-    (p, m) = size(R);
+    m = size(R, 2);
     
     Threads.@threads for j in 1:m
 

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -22,7 +22,7 @@ Calculates the LOD scores for all pairs of traits and markers, by a (multi-threa
 # Notes:
 
 """
-function scan_lite_multivar(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, nb::Int64; 
+function bulkscan_trunk(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2}, nb::Int64; 
                    nt_blas::Int64 = 1, prior_variance = 1.0, prior_sample_size = 0.0,
                    reml::Bool = false)
 
@@ -50,7 +50,7 @@ function scan_lite_multivar(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array
         @simd for i = 1:len
             j = i+(t-1)*len;
 
-            @inbounds lods_currBlock[:, i] = scan_lite_univar(Y0[:, j], X0_intercept, X0_covar, lambda0; 
+            @inbounds lods_currBlock[:, i] = univar_liteqtl(Y0[:, j], X0_intercept, X0_covar, lambda0; 
                                                               prior_variance = prior_variance, prior_sample_size = prior_sample_size,
                                                               reml = reml);
         end
@@ -73,7 +73,7 @@ function scan_lite_multivar(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array
 
         j = m-rem+i;
 
-        lods_remBlock[:, i] = scan_lite_univar(Y0[:, j], X0_intercept, X0_covar, lambda0;
+        lods_remBlock[:, i] = univar_liteqtl(Y0[:, j], X0_intercept, X0_covar, lambda0;
                    reml = reml);
 
     end

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -87,7 +87,7 @@ function tR2LOD!(R::Array{Float64, 2}, n::Int64)
     
     Threads.@threads for j in 1:m
 
-        @inbounds R[:, j] = r2lod.(R[:, j], n)
+        @inbounds R[:, j] .= @views r2lod.(R[:, j], n)
 
     end
     
@@ -118,6 +118,7 @@ Calculates the LOD scores for one trait, using the LiteQTL approach.
 
 Assumes the heritabilities only differ by traits but remain the same across all markers for the same trait;
     hence, VC is estimated once based on the null model and used for all markers scans for that trait.
+    (VC: variance components)
 
 
 """

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -90,9 +90,10 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Floa
 end
 ### Modeling covariates version
 function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2}, 
-                        Covar::Array{Float64, 2}, K::Array{Float64, 2}, nb::Int64; 
-    nt_blas::Int64 = 1, prior_variance = 1.0, prior_sample_size = 0.0,
-    reml::Bool = false)
+                       Covar::Array{Float64, 2}, K::Array{Float64, 2};
+                       nb::Int64 = Threads.nthreads,
+                       nt_blas::Int64 = 1, prior_variance = 1.0, prior_sample_size = 0.0,
+                       reml::Bool = false)
 
 
     m = size(Y, 2);

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -98,7 +98,7 @@ function threaded_map!(f::Function, M::Array{Float64, 2}, args...; dims::Int64 =
 end
 
 """
-scan_lite_univar(y0_j, X0_intercept, X0_covar, lambda0; reml = true)
+univar_liteqtl(y0_j, X0_intercept, X0_covar, lambda0; reml = true)
 
 Calculates the LOD scores for one trait, using the LiteQTL approach.
 
@@ -308,7 +308,9 @@ function gridscan_by_bin(pheno::Array{Float64, 2}, geno::Array{Float64, 2},
     
 end
 
-function reorder_results(blocking_idxs::Array{Array{Bool, 1}, 1}, lods_by_block::Array{Array{Float64, 2}, 1}, m::Int64, p::Int64)
+function reorder_results(blocking_idxs::Array{Array{Bool, 1}, 1}, 
+                         lods_by_block::Array{Array{Float64, 2}, 1}, 
+                         m::Int64, p::Int64)
     
     LOD = Array{Float64, 2}(undef, p, m);
     

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -125,8 +125,9 @@ Assumes the heritabilities only differ by traits but remain the same across all 
 
 
 """
-function univar_liteqtl(y0_j::Array{Float64, 1}, X0_intercept::Array{Float64, 2}, 
-    X0_covar::Array{Float64, 2}, lambda0::Array{Float64, 1}; prior_variance = 0.0, prior_sample_size = 0.0,
+function univar_liteqtl(y0_j::AbstractArray{Float64, 1}, X0_intercept::AbstractArray{Float64, 2}, 
+    X0_covar::AbstractArray{Float64, 2}, lambda0::AbstractArray{Float64, 1}; 
+    prior_variance = 0.0, prior_sample_size = 0.0,
     reml::Bool = false)
 
     n = size(y0_j, 1);

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -125,7 +125,7 @@ Assumes the heritabilities only differ by traits but remain the same across all 
 
 
 """
-function scan_lite_univar(y0_j::Array{Float64, 1}, X0_intercept::Array{Float64, 2}, 
+function univar_liteqtl(y0_j::Array{Float64, 1}, X0_intercept::Array{Float64, 2}, 
     X0_covar::Array{Float64, 2}, lambda0::Array{Float64, 1}; prior_variance = 0.0, prior_sample_size = 0.0,
     reml::Bool = false)
 
@@ -142,7 +142,7 @@ function scan_lite_univar(y0_j::Array{Float64, 1}, X0_intercept::Array{Float64, 
     wX0_covar = rowMultiply(X0_covar, sqrtw);
 
     R = computeR_LMM(wy0, wX0_covar, wX0_intercept);
-    tR2LOD!(R, n);
+    threaded_map!(r2lod, R, n; dims = 2);
 
     return R; # results will be p-by-1, i.e. all LOD scores for the j-th trait and p markers
 

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -1,0 +1,304 @@
+struct Results_by_bin
+    idxs_by_bin::Array{Array{Bool, 1}, 1}
+    LODs_by_bin::Array{Array{Float64, 2}, 1}
+end
+
+"""
+r2lod(r, n)
+
+Given the pairwise correlation `r` and sample size `n`, convert `r` to the corresponding LOD score. 
+
+# Arguments
+
+- r = Float; correlation between a trait and a genetic marker
+- n = Int; sample size
+
+# Value
+
+- lod = Float; LOD score of the corresponding trait and marker
+
+"""
+function r2lod(r::Float64, n::Int64)
+    return -(n/2.0) * log10(1.0-r^2);
+end
+
+
+
+"""
+computeR_LMM(wY, wX, wIntercept)
+
+Calculates the LOD scores for one trait, using the LiteQTL approach.
+
+# Arguments
+- wY = 2d Array of Float; (weighted) a single trait (matrix of one column) or multiple traits (matrix of more than one column)
+- wX = 2d Array of Float; (weighted)
+- wIntercept
+
+# Value
+
+- R = 2d Array of Float; p-by-m matrix the correlation coefficients between each pair of traits (in wY) and markers (in wX)
+
+# Notes:
+
+Inputs are rotated, re-weighted.
+
+"""
+function computeR_LMM(wY::Array{Float64, 2}, wX::Array{Float64, 2}, wIntercept::Array{Float64, 2})
+
+    # exclude the effect of (rotated) intercept (idea is similar as centering data in the linear model case)
+    Y00 = resid(wY, wIntercept);
+    X00 = resid(wX, wIntercept);
+    
+    # n = size(y00, 1);
+
+    # standardize the response and covariates by dividing by their norms
+    norm_Y = mapslices(x -> norm(x), Y00, dims = 1) |> vec;
+    norm_X = mapslices(x -> norm(x), X00, dims = 1) |> vec;
+
+    colDivide!(Y00, norm_Y);
+    colDivide!(X00, norm_X);
+
+    R = X00' * Y00; # p-by-m matrix
+
+    return R
+
+end
+
+"""
+threaded_map!(f, M, args...; dims = dims)
+
+Performs threaded in-place mappings of entries in M based on the given function `f`.
+
+# Arguments
+- f = generic function of R -> R mapping.
+- M = 2d Array of Float
+- args... = splatting of other arguments for function `f(x, args...)`
+- dims = Int; user specified dimension to map along the given matrix `M`
+
+# Value
+
+- No return value; makes in-place mapping to each entry of the input matrix `M`, i.e. same as `f.(M, args...)`.
+
+# Notes:
+
+"""
+function threaded_map!(f::Function, M::Array{Float64, 2}, args...; dims::Int64 = 2)
+    m = size(M, dims);
+    
+    if dims == 1
+        Threads.@threads for i in 1:m
+            @inbounds M[i, :] .= @views f.(M[i, :], args)
+        end
+    elseif dims == 2
+        Threads.@threads for j in 1:m
+            @inbounds M[:, j] .= @views f.(M[:, j], args)
+        end
+    end
+
+end
+
+"""
+scan_lite_univar(y0_j, X0_intercept, X0_covar, lambda0; reml = true)
+
+Calculates the LOD scores for one trait, using the LiteQTL approach.
+
+# Arguments
+
+- y0_j = the j-th trait rotated
+- X0_intercept = the intercept rotated
+- X0_covar = the markers rotated
+- lambda0 = eigenvalues of the kinship matrix
+
+# Keyword Arguments
+
+- reml = Bool indicating whether ML or REML estimate is required; default is REML.
+
+# Value
+
+- R = Float; LOD score of the corresponding trait and marker
+
+# Notes:
+
+Assumes the heritabilities only differ by traits but remain the same across all markers for the same trait;
+    hence, VC is estimated once based on the null model and used for all markers scans for that trait.
+    (VC: variance components)
+
+
+"""
+function scan_lite_univar(y0_j::Array{Float64, 1}, X0_intercept::Array{Float64, 2}, 
+    X0_covar::Array{Float64, 2}, lambda0::Array{Float64, 1}; prior_variance = 0.0, prior_sample_size = 0.0,
+    reml::Bool = false)
+
+    n = size(y0_j, 1);
+    y0 = reshape(y0_j, :, 1);
+
+    # estimate the heritability from the null model and apply it to the reweighting of all markers;
+    vc = fitlmm(y0, X0_intercept, lambda0, [prior_variance, prior_sample_size]; reml = reml);
+    sqrtw = sqrt.(abs.(makeweights(vc.h2, lambda0)));
+
+    # re-weight the data; then in theory, the observations are homoskedestic and independent.
+    wy0 = rowMultiply(y0, sqrtw);
+    wX0_intercept = rowMultiply(X0_intercept, sqrtw);
+    wX0_covar = rowMultiply(X0_covar, sqrtw);
+
+    R = computeR_LMM(wy0, wX0_covar, wX0_intercept);
+    tR2LOD!(R, n);
+
+    return R; # results will be p-by-1, i.e. all LOD scores for the j-th trait and p markers
+
+end
+
+
+### Helper functions for applying LiteQTL approach on multiple traits
+"""
+weighted_liteqtl(Y0, X0, hsq, lambda0)
+
+Calculates LOD scores for all pairs of traits and markers with a given heritability estimate.
+
+# Arguments
+- Y0 = 2d Array of Float; rotated traits 
+- X0 = 2d Array of Float; rotated genotype probabilities
+- hsq = Float; heritability
+- lambda0 = 1d Array of Float; eigenvalues of the kinship matrix
+
+
+# Value
+
+- LOD = 2d Array of Float; matrix of LOD scores for all traits and markers calculated under the given heritability
+
+# Notes:
+
+Inputs data are assumed to be rotated; the shortcut works for only testing 1-df fixed effects.
+
+"""
+function weighted_liteqtl(Y0::Array{Float64, 2}, X0::Array{Float64, 2}, 
+    lambda0::Array{Float64, 1}, hsq::Float64; dims::Int64 = 2)
+
+    n = size(Y0, 1)
+
+    # Pre-process the data based on a common weight matrix (for all traits in Y0)
+    sqrtw = sqrt.(abs.(makeweights(hsq, lambda0)));
+
+    wY0 = rowMultiply(Y0, sqrtw);
+    wX0 = rowMultiply(X0, sqrtw);
+
+    wX0_intercept = reshape(wX0[:, 1], :, 1);
+    wX0_covar = wX0[:, 2:end];
+
+    # Perform the LiteQTL approach for fast calculations of LOD scores
+    LOD = computeR_LMM(wY0, wX0_covar, wX0_intercept);
+
+    threaded_map!(r2lod, LOD, n; dims = dims); # results will be p-by-1, i.e. all LOD scores for the j-th trait and p markers
+
+    return LOD
+end
+
+## GridBulk helper functions:
+function find_optim_h2(h2_list::Array{Float64, 1}, results::Array{Float64, 2})
+    
+    max_h2_idxs = mapslices(x -> findmax(x)[2], results; dims = 1);
+    optim_h2_each_trait = h2_list[max_h2_idxs];
+    
+    return optim_h2_each_trait;
+    
+end
+
+function distribute_traits_by_h2(idxs_sets::Dict{Int64, Float64}, h2_taken::Array{Float64, 1}, m::Int64, nbins::Int64)
+    
+    ids_each_bin = Array{Array{Bool, 1}, 1}(undef, nbins);
+    
+    for t in 1:nbins
+        ids_each_bin[t] = map(x -> get(idxs_sets, x, Inf) == h2_taken[t], 1:m)
+    end
+    
+    return ids_each_bin
+end
+
+function gridscan_by_bin(pheno::Array{Float64, 2}, geno::Array{Float64, 2}, kinship::Array{Float64, 2}, 
+    grid::Array{Float64, 1})
+
+    m = size(pheno, 2);
+
+    Y_std = colStandardize(pheno);
+    (Y0, X0, lambda0) = transform_rotation(Y_std, geno, kinship; addIntercept = true);
+
+    prior = [1.0, 0.1];
+
+    X0_intercept = reshape(X0[:, 1], :, 1);
+
+    # 
+    weights_each_h2 = map(x -> makeweights(x, lambda0), grid); # make weights evaluated on each h2 in grid
+    ell_results = map(x -> wls_multivar(Y0, X0_intercept, x, prior).Ell, weights_each_h2);
+    ell_results = reduce(vcat, ell_results);
+
+
+    optim_h2 = find_optim_h2(grid, ell_results)
+
+
+    idxs_sets = Dict{Int64, Float64}();
+    for i in 1:m
+       idxs_sets[i] = optim_h2[i];
+    end
+
+    h2_taken = unique(values(idxs_sets));
+    nbins = length(h2_taken);
+
+    blocking_idxs = distribute_traits_by_h2(idxs_sets, h2_taken, m, nbins);
+    results = Array{Array{Float64, 2}, 1}(undef, nbins);
+
+    ## Threads.@threads for t in 1:nbins
+
+    for t in 1:nbins
+        results[t] = weighted_liteqtl(Y0[:, blocking_idxs[t]], X0, lambda0, h2_taken[t]);
+    end
+
+    return Results_by_bin(blocking_idxs, results)
+    
+end
+
+function reorder_results(blocking_idxs::Array{Array{Bool, 1}, 1}, lods_by_block::Array{Array{Float64, 2}, 1}, m::Int64, p::Int64)
+    
+    LOD = Array{Float64, 2}(undef, p, m);
+    
+    
+    for block in 1:length(blocking_idxs)
+        idxs_curr_block = blocking_idxs[block];
+        LOD[:, idxs_curr_block] = lods_by_block[block];
+    end
+    
+    return LOD
+    
+end
+
+## MaxBulk helper functions:
+"""
+tmax!(max, toCompare)
+
+Does element-wise comparisons of two 2d Arrays and keep the larger elements in-place. 
+
+# Arguments
+- max = 2d Array of Float; matrix of current maximum values
+- toCompare = 2d Array of Flopat; matrix of values to compare with the current maximum values
+
+# Value
+
+Nothing; does in-place maximizations.
+
+# Notes:
+
+Will modify input matrix `max` by a parallelized loop; uses @tturbo in the package `LoopVectorization.jl`
+
+"""
+function tmax!(max::Array{Float64, 2}, toCompare::Array{Float64, 2})
+    
+    (p, m) = size(max);
+    
+    @tturbo for j in 1:m
+        for i in 1:p
+            
+            max[i, j] = (max[i, j] >= toCompare[i, j]) ? max[i, j] : toCompare[i, j];
+            
+        end
+    end
+    
+end

--- a/src/lmm.jl
+++ b/src/lmm.jl
@@ -68,3 +68,19 @@ function fitlmm(y::Array{Float64, 2}, X::Array{Float64, 2}, lambda::Array{Float6
     est = wls(y, X, makeweights(h2, lambda), prior; reml = reml, loglik = loglik, method = method)
     return LMMEstimates(est.b, est.sigma2, h2, est.ell)
 end
+
+function fitlmm(y::Array{Float64, 2}, X::Array{Float64, 2}, lambda::Array{Float64, 1}, prior::Array{Float64, 1};
+    reml::Bool = false, loglik::Bool = true, method::String = "qr", 
+    h20::Float64 = 0.5, d::Float64 = 1.0)
+
+    function logLik0(h2::Float64)
+    out = wls(y, X, makeweights(h2, lambda), prior; reml = reml, loglik = loglik, method = method)
+    return -out.ell
+    end
+    ## avoid the use of global variable in inner function;
+
+    opt = optimize(logLik0, max(h20-d, 0.0), min(h20+d, 1.0))
+    h2 = opt.minimizer
+    est = wls(y, X, makeweights(h2, lambda), prior; reml = reml, loglik = loglik, method = method)
+    return LMMEstimates(est.b, est.sigma2, h2, est.ell)
+end

--- a/src/lmm.jl
+++ b/src/lmm.jl
@@ -68,19 +68,3 @@ function fitlmm(y::Array{Float64, 2}, X::Array{Float64, 2}, lambda::Array{Float6
     est = wls(y, X, makeweights(h2, lambda), prior; reml = reml, loglik = loglik, method = method)
     return LMMEstimates(est.b, est.sigma2, h2, est.ell)
 end
-
-function fitlmm(y::Array{Float64, 2}, X::Array{Float64, 2}, lambda::Array{Float64, 1}, prior::Array{Float64, 1};
-    reml::Bool = false, loglik::Bool = true, method::String = "qr", 
-    h20::Float64 = 0.5, d::Float64 = 1.0)
-
-    function logLik0(h2::Float64)
-    out = wls(y, X, makeweights(h2, lambda), prior; reml = reml, loglik = loglik, method = method)
-    return -out.ell
-    end
-    ## avoid the use of global variable in inner function;
-
-    opt = optimize(logLik0, max(h20-d, 0.0), min(h20+d, 1.0))
-    h2 = opt.minimizer
-    est = wls(y, X, makeweights(h2, lambda), prior; reml = reml, loglik = loglik, method = method)
-    return LMMEstimates(est.b, est.sigma2, h2, est.ell)
-end

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -36,34 +36,47 @@ A list of output values are returned:
     Output data structure might need some revisions.
 
 """
-
 function scan(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Float64,2};
               prior_variance::Float64 = 0.0, prior_sample_size::Float64 = 0.0, addIntercept::Bool = true,
-              reml::Bool = false, assumption::String = "null", method::String = "qr")
+              reml::Bool = false, assumption::String = "null", method::String = "qr", 
+              permutation_test::Bool = false, nperms::Int64 = 1024, rndseed::Int64 = 0, original::Bool = true)
 
-    if(assumption == "null")
-        return scan_null(y, g, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
-    elseif(assumption == "alt")
-        return scan_alt(y, g, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
+    if addIntercept == false
+        error("Intercept has to be added when no other covariate is given.")
     end
 
-    # n = size(y, 1);
-    # return scan(y, g, ones(n, 1), K; addIntercept = false, ...);
-
-
+    n = size(y, 1);
+    return scan(y, g, ones(n, 1), K; addIntercept = false,
+                prior_variance = prior_variance, prior_sample_size = prior_sample_size,
+                reml = reml, assumption = assumption, method = method, 
+                permutation_test = permutation_test, nperms = nperms, rndseed = rndseed, original = original);
 
 end
 
 function scan(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}, K::Array{Float64,2};
               prior_variance::Float64 = 0.0, prior_sample_size::Float64 = 0.0, addIntercept::Bool = true,
-              reml::Bool = false, assumption::String = "null", method::String = "qr")
+              reml::Bool = false, assumption::String = "null", method::String = "qr", 
+              permutation_test::Bool = false, nperms::Int64 = 1024, rndseed::Int64 = 0, original::Bool = true)
 
-    if(assumption == "null")
-        return scan_null(y, g, covar, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
-    elseif(assumption == "alt")
-        return scan_alt(y, g, covar, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
+
+    if assumption == "null"
+        if permutation_test == true
+            return scan_perms_lite(y, g, covar, K; prior_variance = prior_variance, prior_sample_size = prior_sample_size,
+                                   addIntercept = addIntercept, reml = reml, method = method, 
+                                   nperms = nperms, rndseed = rndseed, original = original);
+        else
+            return scan_null(y, g, covar, K, [prior_variance, prior_sample_size], addIntercept; 
+                             reml = reml, method = method); 
+        end
+    elseif assumption == "alt"
+        if permutation_test == true
+            error("Permutation test option currently is not supported for the alternative assumption.");
+        else
+            return scan_alt(y, g, covar, K, [prior_variance, prior_sample_size], addIntercept; 
+                            reml = reml, method = method)
+    
+        end
     end
-
 end
 
 ###
@@ -103,49 +116,6 @@ A list of output values are returned:
     as `null` (default).
 
 """
-function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, K::Array{Float64, 2}, 
-                   prior::Array{Float64, 1}, addIntercept::Bool;
-                   reml::Bool = false, method::String = "qr")
-
-    # number of markers
-    (n, p) = size(g)
-
-    # num_of_covar = isnothing(covar) ? 1 : (size(covar, 2)+1);
-    num_of_covar = 1;
-
-    # rotate data
-    (y0, X0, lambda0) = transform_rotation(y, g, K; addIntercept = addIntercept)
-    X0_covar = X0[:, 1:num_of_covar];
-
-    if size(X0_covar, 2) == 1
-        X0_covar = reshape(X0_covar, :, 1);
-    end
-
-    # fit null lmm
-    out00 = fitlmm(y0, X0_covar, lambda0, prior; reml = reml, method = method)
-    # weights proportional to the variances
-    sqrtw = sqrt.(makeweights(out00.h2, lambda0))
-    # rescale by weights
-    rowMultiply!(y0, sqrtw)
-    rowMultiply!(X0, sqrtw)
-
-    # perform genome scan
-    rss0 = rss(y0, X0_covar; method = method)[1]
-    lod = zeros(p)
-
-    X = X0[:, 1:(num_of_covar+1)]
-    for i = 1:p
-        X[:, (num_of_covar+1)] = X0[:, num_of_covar+i]
-        rss1 = rss(y0, X; method = method)[1]
-        lod[i] = (-n/2)*(log10(rss1) .- log10(rss0))
-        # lrt = (rss0 - rss1)/out00.sigma2
-        # lod[i] = lrt/(2*log(10))
-    end
-
-    return (sigma2_e = out00.sigma2, h2_null = out00.h2, lod = lod)
-
-end
-
 function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float64, 2}, K::Array{Float64, 2}, 
                    prior::Array{Float64, 1}, addIntercept::Bool;
                    reml::Bool = false, method::String = "qr")
@@ -153,7 +123,7 @@ function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Floa
     # number of markers
     (n, p) = size(g)
 
-    num_of_covar = isnothing(covar) ? 1 : (size(covar, 2)+1);
+    num_of_covar = addIntercept ? (size(covar, 2)+1) : size(covar, 2);
 
     # rotate data
     (y0, X0, lambda0) = transform_rotation(y, [covar g], K; addIntercept = addIntercept)
@@ -170,6 +140,7 @@ function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Floa
     # rescale by weights
     rowMultiply!(y0, sqrtw)
     rowMultiply!(X0, sqrtw)
+    rowMultiply!(X0_covar, sqrtw);
 
     # perform genome scan
     rss0 = rss(y0, X0_covar; method = method)[1]
@@ -223,57 +194,6 @@ A list of output values are returned:
     field is passed as `alt`.
 
 """
-function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, K::Array{Float64, 2}, 
-                  prior::Array{Float64, 1}, addIntercept::Bool;
-                  reml::Bool = false, method::String = "qr")
-
-    # number of markers
-    (n, p) = size(g)
-
-    # num_of_covar = isnothing(covar) ? 1 : (size(covar, 2)+1);
-    num_of_covar = 1;
-
-    # rotate data
-    (y0, X0, lambda0) = transform_rotation(y, g, K; addIntercept = addIntercept)
-    X0_covar = X0[:, 1:num_of_covar];
-
-    if size(X0_covar, 2) == 1
-        X0_covar = reshape(X0_covar, :, 1);
-    end
-
-    pve_list = Array{Float64, 1}(undef, p);
-
-    # fit null lmm
-    if reml == false
-        out00 = fitlmm(y0, X0_covar, lambda0, prior; reml = reml, method = method);
-    end
-
-    lod = zeros(p);
-
-    X = X0[:, 1:(num_of_covar+1)]
-
-    for i = 1:p
-        X[:, (num_of_covar+1)] = X0[:, num_of_covar+i]
-
-        out11 = fitlmm(y0, X, lambda0, prior; reml = reml, method = method);
-
-        if reml
-            sqrtw_alt = sqrt.(makeweights(out11.h2, lambda0));
-            wls_alt = wls(y0, X, sqrtw_alt, prior; reml = false);
-            wls_null = wls(y0, X00, sqrtw_alt, prior; reml = false);
-            lod[i] = (wls_alt.ell - wls_null.ell)/log(10);
-        else 
-            lod[i] = (out11.ell - out00.ell)/log(10);
-        end
-
-        pve_list[i] = out11.h2;
-    end
-
-    return (sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod)
-
-
-end
-
 function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float64, 2}, K::Array{Float64, 2}, 
                   prior::Array{Float64, 1}, addIntercept::Bool;
                   reml::Bool = false, method::String = "qr")
@@ -281,7 +201,7 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
     # number of markers
     (n, p) = size(g)
 
-    num_of_covar = isnothing(covar) ? 1 : (size(covar, 2)+1);
+    num_of_covar = addIntercept ? (size(covar, 2)+1) : size(covar, 2);
 
     # rotate data
     (y0, X0, lambda0) = transform_rotation(y, [covar g], K; addIntercept = addIntercept)
@@ -294,9 +214,7 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
     pve_list = Array{Float64, 1}(undef, p);
 
     # fit null lmm
-    if reml == false
-        out00 = fitlmm(y0, X0_covar, lambda0, prior; reml = reml, method = method);
-    end
+    out00 = fitlmm(y0, X0_covar, lambda0, prior; reml = reml, method = method);
 
     lod = zeros(p);
 
@@ -319,7 +237,7 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
         pve_list[i] = out11.h2;
     end
 
-    return (sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod)
+    return (sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod);
 
 
 end
@@ -365,8 +283,8 @@ function scan_perms(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Float64,2
         error("Can only handle one trait.")
     end
 
-    sy = colStandardize(y);
-    sg = colStandardize(g);
+    # sy = colStandardize(y);
+    # sg = colStandardize(g);
 
     # n - the sample size
     # p - the number of markers
@@ -374,7 +292,7 @@ function scan_perms(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Float64,2
 
     ## Note: estimate once the variance components from the null model and use for all marker scans
     # fit lmm
-    (y0, X0, lambda0) = transform_rotation(sy, sg, K; addIntercept = addIntercept); # rotation of data
+    (y0, X0, lambda0) = transform_rotation(y, g, K; addIntercept = addIntercept); # rotation of data
     (r0, X00) = transform_reweight(y0, X0, lambda0; prior_a = prior_variance, prior_b = prior_sample_size, 
                                                     reml = reml, method = method); # reweighting and taking residuals
 
@@ -418,19 +336,23 @@ function scan_perms(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Float64,2
 end
 
 
-function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Float64,2};
-    prior_variance::Float64 = 1.0, prior_sample_size::Float64 = 0.0, addIntercept::Bool = true, method::String = "qr",
-    nperms::Int64 = 1024, rndseed::Int64 = 0, 
-    reml::Bool = false, original::Bool = true)
+function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}, K::Array{Float64,2};
+                         prior_variance::Float64 = 1.0, prior_sample_size::Float64 = 0.0, 
+                         addIntercept::Bool = true, method::String = "qr",
+                         nperms::Int64 = 1024, rndseed::Int64 = 0, 
+                         reml::Bool = false, original::Bool = true)
 
 
     # check the number of traits as this function only works for permutation testing of univariate trait
-    if(size(y, 2) != 1)
+    if size(y, 2) != 1
         error("Can only handle one trait.")
     end
 
-    sy = colStandardize(y);
-    sg = colStandardize(g);
+    ## Issue: when covar is passed with a vector that is proportional to the column of ones, standard deviation will be 0
+    ## it is recommended that the user to standardize the input matrices and then use the prior_variance of 1.
+    # sy = colStandardize(y);
+    # sg = colStandardize(g);
+    # scovar = colStandardize(covar);
 
 
     # n - the sample size
@@ -439,8 +361,10 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Floa
 
     ## Note: estimate once the variance components from the null model and use for all marker scans
     # fit lmm
-    (y0, X0, lambda0) = transform_rotation(sy, sg, K; addIntercept = addIntercept); # rotation of data
-    (r0, X00) = transform_reweight(y0, X0, lambda0; prior_a = prior_variance, prior_b = prior_sample_size, reml = reml, method = method); # reweighting and taking residuals
+    (y0, X0, lambda0) = transform_rotation(y, [covar g], K; addIntercept = addIntercept); # rotation of data
+    (r0, X00) = transform_reweight(y0, X0, lambda0; 
+                                   prior_a = prior_variance, 
+                                   prior_b = prior_sample_size, reml = reml, method = method); # reweighting and taking residuals
 
     # If no permutation testing is required, move forward to process the single original vector
     if nperms == 0
@@ -463,7 +387,7 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Floa
     colDivide!(X00, norm_X);
 
     lods = X00' * r0perm
-    tR2LOD!(lods, n);
+    threaded_map!(r2lod, lods, n);
 
     return lods
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -42,10 +42,15 @@ function scan(y::Array{Float64,2}, g::Array{Float64,2}, K::Array{Float64,2};
               reml::Bool = false, assumption::String = "null", method::String = "qr")
 
     if(assumption == "null")
-    return scan_null(y, g, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
+        return scan_null(y, g, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
     elseif(assumption == "alt")
-    return scan_alt(y, g, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
+        return scan_alt(y, g, K, [prior_variance, prior_sample_size], addIntercept; reml = reml, method = method)
     end
+
+    # n = size(y, 1);
+    # return scan(y, g, ones(n, 1), K; addIntercept = false, ...);
+
+
 
 end
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -1,5 +1,6 @@
 ###########################################################
-# genome scan function; no covariates, two genotype groups
+# Genome scan functions for a single trait plus permutation testing:
+# allow modeling additional covariates, two genotype groups
 ###########################################################
 
 """
@@ -140,7 +141,7 @@ function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, K::Array{Float64,
 
 end
 
-function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar, K::Array{Float64, 2}, 
+function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float64, 2}, K::Array{Float64, 2}, 
                    prior::Array{Float64, 1}, addIntercept::Bool;
                    reml::Bool = false, method::String = "qr")
 
@@ -268,9 +269,9 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, K::Array{Float64, 
 
 end
 
-function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar, K::Array{Float64, 2}, 
-                 prior::Array{Float64, 1}, addIntercept::Bool;
-                 reml::Bool = false, method::String = "qr")
+function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float64, 2}, K::Array{Float64, 2}, 
+                  prior::Array{Float64, 1}, addIntercept::Bool;
+                  reml::Bool = false, method::String = "qr")
 
     # number of markers
     (n, p) = size(g)

--- a/src/wls.jl
+++ b/src/wls.jl
@@ -9,6 +9,12 @@ mutable struct LSEstimates
     ell::Float64
 end
 
+struct LSEstimates_multivar
+    B::Array{Float64, 2}
+    Sigma2::Array{Float64, 2}
+    Ell::Array{Float64, 2}
+end
+
 
 """
 wls: Weighted least squares estimation
@@ -86,9 +92,88 @@ function wls(y::Array{Float64, 2}, X::Array{Float64, 2}, w::Array{Float64, 1}, p
         ll = missing;
     end
 
-    return LSEstimates(coef, sigma2_e, ll)
+    return LSEstimates(coef, sigma2_e, ll);
 
 end
+
+"""
+wls_multivar: Multivariate weighted least-square estimation
+
+"""
+function wls_multivar(Y::Array{Float64, 2}, X::Array{Float64, 2}, w::Array{Float64, 1}, prior::Array{Float64, 1};
+             reml::Bool = false, loglik::Bool = true, method::String = "qr")
+
+    (n, p) = size(X); # get number of observations and the number of markers from geno dimensions      
+
+    n = size(Y, 1); # get number of observations       
+
+    # check if weights are positive
+    if(any(w .<= .0))
+        error("Some weights are not positive.")
+    end
+
+    # square root of the weights
+    sqrtw = sqrt.(w)
+
+    # logdetXtX = logdet(X' * X); constant term that does not depend on the parameters (weights); is not needed
+
+    # scale by weights
+    YY = rowMultiply(Y, sqrtw)
+    XX = rowMultiply(X, sqrtw)
+
+    # least squares solution
+    # faster but numerically less stable
+    if(method == "cholesky")
+        fct = cholesky(XX'XX)
+        coef = fct\(XX'YY)
+        logdetXXtXX = logdet(fct)
+    end
+
+    # slower but numerically more stable
+    if(method == "qr")
+        fct = qr(XX)
+        coef = fct\YY # will be a matrix with each column be the fitted coefficients for one response variable
+
+        # logdetXXtXX = 2*logdet(fct.R) # need 2 for logdet(X'X)
+        # logdetXXtXX = logdet(fct.R' * fct.R);
+        logdetXXtXX = 2*logabsdet(fct.R)[1];
+    end
+
+    YYhat = XX*coef
+    rss0 = mapslices(x -> sum(x.^2), YY-YYhat; dims = 1)
+
+    if prior[2] > 0.0
+        prior_df = prior[2]+2;
+    else
+        prior_df = prior[2];
+    end
+
+    if(reml)
+        sigma2_e = (rss0.+prior[1]*prior[2])./((n-p)+prior_df)
+    else
+        sigma2_e = (rss0.+prior[1]*prior[2])./(n+prior_df)
+    end
+
+    
+    # see formulas (2) and (3) of Kang (2008)
+    if(loglik)
+
+        ll = -0.5 * ((n+prior[2])*log.(sigma2_e) .- sum(log.(w)) .+ (rss0.+prior[1]*prior[2])./sigma2_e)
+        
+        if(reml)
+            # ell = ell + 0.5 * (p*log(2pi*sigma2) + logdetXtX - logdetXXtXX) # full log-likelihood including the constant terms;
+            ll = ll + 0.5 * (p*log(sigma2_e) - logdetXXtXX)
+        end
+        
+    else
+        ll = missing;
+    end
+    
+
+    return LSEstimates_multivar(coef, sigma2_e, ll);
+    
+end
+
 
 """
 rss: residual sum of squares
@@ -102,7 +187,6 @@ the function returns the residual sum of squares of each column. The
 return values is a (row) vector of length equal to the number of columns of y.
 
 """
-
 function rss(y::Array{Float64, 2}, X::Array{Float64, 2}; method = "qr")
 
     r = resid(y, X; method = method)

--- a/test/bulkscan_test.jl
+++ b/test/bulkscan_test.jl
@@ -61,7 +61,8 @@ test_bulkscan_null = quote
     stand_pheno = BulkLMM.colStandardize(pheno[:, 705:1112]);
     stand_geno = BulkLMM.colStandardize(geno);
 
-    test_bulkscan_null = BulkLMM.bulkscan_null(stand_pheno, stand_geno, kinship, 4;
+    test_bulkscan_null = BulkLMM.bulkscan_null(stand_pheno, stand_geno, kinship;
+                                               nb = 4, 
                                                prior_variance = 1.0, 
                                                prior_sample_size = 0.1);
 

--- a/test/bulkscan_test.jl
+++ b/test/bulkscan_test.jl
@@ -61,7 +61,7 @@ test_scan_multivar = quote
     stand_pheno = BulkLMM.colStandardize(pheno[:, 705:1112]);
     stand_geno = BulkLMM.colStandardize(geno);
 
-    test_multivar = BulkLMM.scan_lite_multivar(stand_pheno, stand_geno, kinship, 4;
+    test_multivar = BulkLMM.bulkscan_trunk(stand_pheno, stand_geno, kinship, 4;
                                                prior_variance = 1.0, 
                                                prior_sample_size = 0.1);
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,5 +19,8 @@ include("testHelpers.jl");
     include("lmm_test.jl");
     include("transform_helpers_test.jl");
     include("scan_test_lmmlite.jl");
+    # for now, only tested consistency of algorithms for adding covariates features,
+    # may perform additional tests with other's implementations, e.g. GEMMA, R/qtl...
+    include("scan_covar_test.jl");
     include("bulkscan_test.jl");
 end;

--- a/test/scan_covar_test.jl
+++ b/test/scan_covar_test.jl
@@ -1,0 +1,25 @@
+# Tests of single trait scan function scan() interface with adding covariates:
+
+## Consider the 705-th trait
+pheno_y = reshape(pheno[:, 705], :, 1);
+## Take measurements of the first three traits as pseudo-covariates:
+pseudo_covar = pheno[:, 1:3];
+
+
+## For short wait-time reason, test by comparing single trait with covariates scan with the 
+## multiple trait null_grid algorithm function bulkscan_null_grid()
+test_scan_covar = scan(pheno_y, geno, pseudo_covar, kinship);
+test_grid_covar = bulkscan_null_grid(pheno, geno, pseudo_covar, kinship, 
+                                     vcat(collect(0.0:0.05:0.95), test_scan_covar.h2_null));
+
+tol = 1e-8;    
+
+# Test that the error case will be successfully detected:
+try 
+    scan(pheno_y, geno, kinship; addIntercept = false)
+catch e
+    @test e.msg == "Intercept has to be added when no other covariate is given."
+end
+
+@test mean(abs.(test_scan_covar.lod .- test_grid_covar[:, 705])) <= tol
+

--- a/test/wls_results_test.jl
+++ b/test/wls_results_test.jl
@@ -23,19 +23,23 @@ end
 N = 100; # number of observations
 p = 1; # 1-df test
 beta = [1.0, 0.5]; # true effects plus intercept
+beta2 = [0.5, 0.5]; # true effects plus intercept of the second dependent variable
 prior = [0.0, 0.0]; # default setting not using prior correction
 
 # Construct means
 group = repeat([0.0, 1.0], inner = Int64(N/2));
 mu = beta[1] .+ group .* beta[2];
+mu2 = beta2[1] .+ group .* beta2[2];
 
 # Construct heteroscedestic errors
 vars = rand(Uniform(0, 0.1), 100);
 errors_dist = generateErrors(vars);
 errors = rand(errors_dist, 1);
+errors2 = rand(errors_dist, 1);
 
 # Finally, construct heteroscedestic dependent variables
 y = mu .+ errors;
+y2 = mu2 .+ errors2;
 
 X = hcat(repeat([1.0], inner = N), group) # design matrix
 weights = 1.0 ./ sqrt.(vars); # construct weights by standard deviations
@@ -55,21 +59,21 @@ function ls(y::Array{Float64, 2}, X::Array{Float64, 2};
     rss0 = sum((y-yhat).^2)
 
     if reml 
-    sigma2 = rss0/(n-p)
+        sigma2 = rss0/(n-p)
     else
-    sigma2 = rss0/n
+        sigma2 = rss0/n
     end
 
     if loglik 
-    if reml
-        logdetSigma = (n-p)*log(sigma2)
-    else
-        logdetSigma = n*log(sigma2)
-    end
+        if reml
+            logdetSigma = (n-p)*log(sigma2)
+        else
+            logdetSigma = n*log(sigma2)
+        end
 
-    ell = -0.5 * ( logdetSigma + rss0/sigma2 )
+        ell = -0.5 * ( logdetSigma + rss0/sigma2 )
     else
-    ell = missing
+        ell = missing
     end
 
     return LSEstimates(b, sigma2, ell)
@@ -83,6 +87,7 @@ end
 
 # Get results from wls implementation
 result_wls = BulkLMM.wls(y, X, weights, prior; reml = false, loglik = true, method = "cholesky");
+result_wls_multivar = BulkLMM.wls_multivar([y y2], X, weights, prior; reml = false, loglik = true, method = "cholesky");
 
 # Get weighted LS results by manually weighting and then perform OLS:
 W = weights .* (1.0*Matrix(I, N, N));
@@ -100,10 +105,12 @@ function biasSquared(est::AbstractArray{Float64, 2}, truth::AbstractArray{Float6
 end
 
 tol = 1e-2;
-truth = reshape([1.0 0.5], 2, 1);
+true_b = reshape([1.0 0.5], 2, 1);
+true_B = [beta beta2];
 
 @testset "simple test WLS" begin
     @test biasSquared(result_wls.b, result_ls.b) <= tol^4
-    @test biasSquared(result_wls.b, truth) <= tol
-    @test biasSquared(result_ls.b, truth) <= tol
+    @test biasSquared(result_wls.b, true_b) <= tol
+    @test biasSquared(result_ls.b, true_b) <= tol
+    @test biasSquared(result_wls_multivar.B, true_B) <= tol
 end;


### PR DESCRIPTION
## New features of all functions in general:
- All scan functions (for single trait and multiple traits) now allow to adjust for additional covariates.

## Multiple traits scan functions:
- Renamed the function previous called `scan_lite_multivar()` now as `bulkscan_null()`;

- The 4th argument in `bulkscan_null()` (previously, `scan_lite_multivar()`) is now an optional keyword argument named `nb` (for the number of parallel blocks), and has default value set to equal to `Threads.nthreads()`;

- Added two other functions `bulkscan_null_grid()`, `bulkscan_alt_grid()` which can be viewed as shortcuts of doing the exact scans of multiple traits under the "null" and "alt" assumption, using a grid-search approach for estimating the heritability;

- Probably needs a general wrapper function `bulkscan()` as a general user interface for multiple traits scans and allows the user to select which specific function to execute, based on the preference of precision and/or runtime.

## Other small modifications (not in the functions open to the user):
- `tR2LOD!()` is now a more general mapping function over elements in a collection named `threaded_map()`;
- Added multivariate WLS function (requires the same weight matrix for all input dependent variables);
- Some supporting functions for `bulkscan_null_grid()`.