### PR TITLE
Allowed output format of p-values; allowed input of vector-typed single traits in scan()

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ kinship = round.(kinship; digits = 12);
 
 For example, to conduct genome-wide associations mapping on the
 1112-th trait, we can run the function `scan()` with inputs of the trait (as
-a 2D-array of one column), geno matrix, and the kinship matrix.
+a 2D-array of one column), geno matrix, and the kinship matrix. Type `?scan()` for more 
+detailed description of the function.
 
 
 ```julia
@@ -308,40 +309,47 @@ multi-threads](https://docs.julialang.org/en/v1/manual/multi-threading/)
 or switch to a multi-threaded *julia* kernel if using Jupyter
 notebooks.
 
-Then, run the function `bulkscan_null()` with the matrices of
-traits, genome markers, kinship. The fourth required input is the
-number of parallelized tasks and we recommend it to be the number of
-*julia* threads.
+Then, run the function `bulkscan()` with the matrices of the
+traits of interest, genome markers, and the kinship. Type `?bulkscan()` for more 
+detailed description of the function.
 
-Here, we started a 16-threaded *julia* and executed the program on a
-Linux server with the Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz to
-get the LOD scores for all **~35k** BXD traits:
+Here, we started a 16-threaded *julia* session in julia version 1.9.2. Specific session info 
+is as follows:
+```julia
+	versioninfo()
+```
+
+	Julia Version 1.9.2
+	Commit e4ee485e909 (2023-07-05 09:39 UTC)
+	Platform Info:
+		OS: Linux (x86_64-linux-gnu)
+		CPU: 48 × Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz
+		WORD_SIZE: 64
+		LIBM: libopenlibm
+		LLVM: libLLVM-14.0.6 (ORCJIT, cascadelake)
+		Threads: 17 on 48 virtual cores
+	Environment:
+		JULIA_NUM_THREADS = 16
 
 
 ```julia
-@time multiple_results_allTraits = bulkscan_null(pheno_processed, geno_processed, kinship; nb = Threads.nthreads());
+@time multiple_results_allTraits = bulkscan(pheno_processed, geno_processed, kinship);
 ```
 
-     82.421037 seconds (2.86 G allocations: 710.821 GiB, 41.76% gc time)
+    2.112011 seconds (107.94 k allocations: 5.053 GiB, 2.59% gc time)
 
+Please Note: the default method and modeling options for `bulkscan()` takes an approximated approach for 
+the best runtime performance. The user may choose to use other methods and options provided for more precision but longer runtime, following the detailed instructions in `?bulkscan()`.
 
 The output `multiple_results_allTraits` is an object containing our model results:
 - the matrix of LOD scores $L_{p \times m}$, where $p$ is the number of markers and $m$ is number of traits; each column corresponds to the LOD scores resulting from performing GWAS on each given trait.
-- the vector of heritability estimate per trait, `h2_null_list`, obtained from fitting the null model. 
-
-Similarly as the single trait scan function `scan()`, variance components are estimated from maximum-likelihood (ML) by default ("reml = false"). The user may choose REML for estimating by specifying in the input "reml = true".
+- variance components (heritability) results will be returned in various formats depending on the specific method and other options by the user. For more details, enter `?bulkscan()`.
 
 ```julia
 size(multiple_results_allTraits.L)
 ```
 
     (7321, 35554)
-
-```julia
-length(multiple_results_allTraits.h2_null_list)
-```
-
-    35554
 
 To visualize the multiple-trait scan results, we can use the plotting function `plot_eQTL` from `BigRiverQTLPlots.jl` to generate the eQTL plot.
 In the following example, we only plot the LOD scores that are above 5.0 by calling the function and specifying in the optional argument `threshold = 5.0`:

--- a/src/BulkLMM.jl
+++ b/src/BulkLMM.jl
@@ -6,6 +6,8 @@ module BulkLMM
     using Random, Distributions
     
     include("./util.jl");
+    export p2lod, lod2p
+    
     include("./kinship.jl");
     export calcKinship
 

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -21,6 +21,7 @@ Perform genome scan for multiple univariate traits and a set of genome markers
 - `method::String`: Keyword argument indicating which multi-trait scan method will be used; currently supported 
     options: "null-grid" (fastest, grid-search approximated Null-LMM), "null-exact" (Null-LMM), and "alt-grid" 
     (grid-search approximated Exact-LMM)
+- `output_pvals::Bool`: Option to additionally report the LRT p-values (default: false)
 
 ## Modeling Additional Covariates:   
 - `Z::AbstractArray{Float64, 2}`: Matrix of additional non-genetic covariates (should be independent to tested 
@@ -72,6 +73,9 @@ The output of the single-trait scan function is an object. Depending on the user
 - `MT_out.L::Array{Float64, 2}`: 2-dimensional array (dimension: p*m) consisting of the LOD scores for all input traits; each column 
     contains the LOD scores for one trait
 
+## If the option for reporting p-values is on, the p-values results will be returned as:
+- `MT_out.Pvals_mat::Array{Float64, 2}`: 2-dimensional array (dimension: p*m) consisting of the p-values corresponding
+    to the LOD scores in MT_out.L
 
 """
 function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 2};
@@ -82,7 +86,9 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 
                   prior_variance::Float64 = 1.0, prior_sample_size::Float64 = 0.0,
                   reml::Bool = false, optim_interval::Int64 = 1,
                   # option for kinship decomposition scheme:
-                  decomp_scheme::String = "eigen"
+                  decomp_scheme::String = "eigen",
+                  # option for returning p-values results:
+                  output_pvals::Bool = false
                   )
 
     n = size(Y, 1);
@@ -99,7 +105,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 
                     weights = weights,
                     prior_variance = prior_variance, prior_sample_size = prior_sample_size,
                     reml = reml, optim_interval = optim_interval,
-                    decomp_scheme = decomp_scheme)
+                    decomp_scheme = decomp_scheme, output_pvals = output_pvals)
 
 
 end
@@ -113,10 +119,12 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
                   prior_variance::Float64 = 1.0, prior_sample_size::Float64 = 0.0,
                   reml::Bool = false, optim_interval::Int64 = 1,
                   # option for kinship decomposition scheme:
-                  decomp_scheme::String = "eigen")
+                  decomp_scheme::String = "eigen",
+                  # option for returning p-values results:
+                  output_pvals::Bool = false)
     
     if method == "null-exact"
-        return bulkscan_null(Y, G, Covar, K; 
+        bulkscan_results =  bulkscan_null(Y, G, Covar, K; 
                              nb = nb, nt_blas = nt_blas,
                              addIntercept = addIntercept, 
                              weights = weights,
@@ -126,7 +134,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
     end
 
     if method == "null-grid"
-        return bulkscan_null_grid(Y, G, Covar, K, h2_grid; 
+        bulkscan_results = bulkscan_null_grid(Y, G, Covar, K, h2_grid; 
                                   weights = weights,
                                   addIntercept = addIntercept,
                                   prior_variance = prior_variance, prior_sample_size = prior_sample_size,
@@ -135,7 +143,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
     end
 
     if method == "alt-grid"
-        return bulkscan_alt_grid(Y, G, Covar, K, h2_grid; 
+        bulkscan_results = bulkscan_alt_grid(Y, G, Covar, K, h2_grid; 
                                   weights = weights,
                                   addIntercept = addIntercept,
                                   prior_variance = prior_variance, prior_sample_size = prior_sample_size,
@@ -143,6 +151,12 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
                                   decomp_scheme = decomp_scheme);
     end
 
+    if output_pvals
+        Pvals_mat = lod2p.(bulkscan_results.L, 1);
+        return (bulkscan_results, Pvals_mat = Pvals_mat)
+    else
+        return bulkscan_results
+    end
 end
 
 ###########################################################

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -153,10 +153,10 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
 
     if output_pvals
         Pvals_mat = lod2p.(bulkscan_results.L, 1);
-        return (bulkscan_results, Pvals_mat = Pvals_mat)
-    else
-        return bulkscan_results
+        bulkscan_results.Pvals_mat = Pvals_mat
     end
+    
+    return bulkscan_result
 end
 
 ###########################################################

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -153,7 +153,8 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
 
     if output_pvals
         Pvals_mat = lod2p.(bulkscan_results.L, 1);
-        return bulkscan_results
+        temp_tuple = (Pvals_mat = Pvals_mat, output_pvals = true);
+        return merge(bulkscan_results, temp_tuple)
     else
         return bulkscan_results
     end

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -88,7 +88,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 
                   # option for kinship decomposition scheme:
                   decomp_scheme::String = "eigen",
                   # option for returning p-values results:
-                  output_pvals::Bool = false
+                  output_pvals::Bool = false, chisq_df::Int64 = 1
                   )
 
     n = size(Y, 1);
@@ -105,7 +105,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 
                     weights = weights,
                     prior_variance = prior_variance, prior_sample_size = prior_sample_size,
                     reml = reml, optim_interval = optim_interval,
-                    decomp_scheme = decomp_scheme, output_pvals = output_pvals)
+                    decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df)
 
 
 end
@@ -121,7 +121,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
                   # option for kinship decomposition scheme:
                   decomp_scheme::String = "eigen",
                   # option for returning p-values results:
-                  output_pvals::Bool = false)
+                  output_pvals::Bool = false, chisq_df::Int64 = 1)
     
     if method == "null-exact"
         bulkscan_results =  bulkscan_null(Y, G, Covar, K; 
@@ -152,8 +152,8 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
     end
 
     if output_pvals
-        Pvals_mat = lod2p.(bulkscan_results.L, 1);
-        temp_tuple = (Pvals_mat = Pvals_mat, output_pvals = true);
+        Pvals_mat = lod2p.(bulkscan_results.L, chisq_df);
+        temp_tuple = (Pvals_mat = Pvals_mat, Chisq_df = chisq_df);
         return merge(bulkscan_results, temp_tuple)
     else
         return bulkscan_results

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -153,10 +153,11 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
 
     if output_pvals
         Pvals_mat = lod2p.(bulkscan_results.L, 1);
-        bulkscan_results.Pvals_mat = Pvals_mat
+        return bulkscan_results
+    else
+        return bulkscan_results
     end
-    
-    return bulkscan_result
+
 end
 
 ###########################################################

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -105,7 +105,7 @@ function scan(y::Array{Float64, 1}, g::Array{Float64, 2}, K::Array{Float64, 2};
               # option for kinship decomposition scheme:
               decomp_scheme::String = "eigen",
               # option for returning p-values results:
-              output_pvals::Bool = false
+              output_pvals::Bool = false, chisq_df::Int64 = 1
               )
 
     return scan(reshape(y, :, 1), g, K; 
@@ -115,7 +115,7 @@ function scan(y::Array{Float64, 1}, g::Array{Float64, 2}, K::Array{Float64, 2};
                 reml = reml, assumption = assumption, method = method, optim_interval = optim_interval,
                 permutation_test = permutation_test, nperms = nperms, rndseed = rndseed,
                 profileLL = profileLL, markerID = markerID, h2_grid = h2_grid,
-                decomp_scheme = decomp_scheme, output_pvals = output_pvals)
+                decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df)
 
 end
 
@@ -133,7 +133,7 @@ function scan(y::Array{Float64, 1}, g::Array{Float64, 2}, covar::Array{Float64, 
               # option for kinship decomposition scheme:
               decomp_scheme::String = "eigen",
               # option for returning p-values results:
-              output_pvals::Bool = false
+              output_pvals::Bool = false, chisq_df::Int64 = 1
     )
 
     return scan(reshape(y, :, 1), g, covar, K; 
@@ -143,7 +143,7 @@ function scan(y::Array{Float64, 1}, g::Array{Float64, 2}, covar::Array{Float64, 
                 reml = reml, assumption = assumption, method = method, optim_interval = optim_interval,
                 permutation_test = permutation_test, nperms = nperms, rndseed = rndseed,
                 profileLL = profileLL, markerID = markerID, h2_grid = h2_grid,
-                decomp_scheme = decomp_scheme, output_pvals = output_pvals)
+                decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df)
 
 end 
 
@@ -161,7 +161,7 @@ function scan(y::Array{Float64, 2}, g::Array{Float64, 2}, K::Array{Float64, 2};
               # option for kinship decomposition scheme:
               decomp_scheme::String = "eigen",
               # option for returning p-values results:
-              output_pvals::Bool = false
+              output_pvals::Bool = false, chisq_df::Int64 = 1
               )
 
     if addIntercept == false
@@ -176,7 +176,7 @@ function scan(y::Array{Float64, 2}, g::Array{Float64, 2}, K::Array{Float64, 2};
                 reml = reml, assumption = assumption, method = method, optim_interval = optim_interval,
                 permutation_test = permutation_test, nperms = nperms, rndseed = rndseed,
                 profileLL = profileLL, markerID = markerID, h2_grid = h2_grid,
-                decomp_scheme = decomp_scheme, output_pvals = output_pvals)
+                decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df)
 end
 
 function scan(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}, K::Array{Float64,2};
@@ -193,7 +193,7 @@ function scan(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}
               # option for kinship decomposition scheme:
               decomp_scheme::String = "eigen",
               # option for returning p-values results:
-              output_pvals::Bool = false
+              output_pvals::Bool = false, chisq_df::Int64 = 1
               )
 
     n = size(y, 1);
@@ -218,7 +218,7 @@ function scan(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}
                     reml = reml, assumption = assumption, method = method, optim_interval = optim_interval,
                     permutation_test = permutation_test, nperms = nperms, rndseed = rndseed,
                     profileLL = profileLL, markerID = markerID, h2_grid = h2_grid,
-                    decomp_scheme = decomp_scheme, output_pvals = output_pvals)
+                    decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df)
     else
         y_st = y;
         g_st = g;
@@ -235,7 +235,7 @@ function scan(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}
         else
             results = scan_null(y_st, g_st, covar_st, K_st, [prior_variance, prior_sample_size], addIntercept; 
                                 reml = reml, method = method, optim_interval = optim_interval,
-                                decomp_scheme = decomp_scheme, output_pvals = output_pvals);
+                                decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df);
         end 
     elseif assumption == "alt"
         if permutation_test == true
@@ -243,7 +243,7 @@ function scan(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}
         else
             results = scan_alt(y_st, g_st, covar_st, K_st, [prior_variance, prior_sample_size], addIntercept; 
                                reml = reml, method = method, optim_interval = optim_interval,
-                               decomp_scheme = decomp_scheme, output_pvals = output_pvals)
+                               decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df)
         end
 
     else
@@ -312,7 +312,7 @@ function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Floa
                    reml::Bool = false, method::String = "qr", optim_interval::Int64 = 1,
                    decomp_scheme::String = "eigen", 
                    # option for returning p-values results:
-                   output_pvals::Bool = false)
+                   output_pvals::Bool = false, chisq_df::Int64 = 1)
 
     # number of markers
     (n, p) = size(g)
@@ -351,7 +351,7 @@ function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Floa
     end
 
     if output_pvals
-        pvals = lod2p.(lod, 1);
+        pvals = lod2p.(lod, chisq_df);
         return (sigma2_e = out00.sigma2, h2_null = out00.h2, lod = lod, pvals = pvals)
     else
         return (sigma2_e = out00.sigma2, h2_null = out00.h2, lod = lod)
@@ -399,7 +399,7 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
                   reml::Bool = false, method::String = "qr", optim_interval::Int64 = 1,
                   decomp_scheme::String = "eigen",
                   # option for returning p-values results:
-                  output_pvals::Bool = false)
+                  output_pvals::Bool = false, chisq_df::Int64 = 1)
 
     # number of markers
     (n, p) = size(g)
@@ -443,7 +443,7 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
     end
 
     if output_pvals
-        pvals = lod2p.(lod, 1);
+        pvals = lod2p.(lod, chisq_df);
         return (sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod, pvals = pvals);
     else
         return (sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod);
@@ -489,7 +489,7 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
                          reml::Bool = false,
                          decomp_scheme::String = "eigen",
                          # option for returning p-values results:
-                         output_pvals::Bool = false)
+                         output_pvals::Bool = false, chisq_df::Int64 = 1)
 
 
     # check the number of traits as this function only works for permutation testing of univariate trait
@@ -546,8 +546,8 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
     L_perms = L[:, 2:end]; # lod scores for the permuted copies of the original, excluding the lod scores for the original trait
 
     if output_pvals
-        pvals = lod2p.(lod, 1);
-        Pvals_perms = lod2p.(L_perms, 1);
+        pvals = lod2p.(lod, chisq_df);
+        Pvals_perms = lod2p.(L_perms, chisq_df);
         return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, pvals = pvals,
                                                         L_perms = L_perms, Pvals_perms = Pvals_perms)
     else

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -10,7 +10,7 @@ Perform genome scan for univariate trait and a set of genome markers
 
 # Required Inputs
 
-- `y::Array{Float64, 2}`: Single univariate quantitative trait of N measurements (dimension: N*1)
+- `y::Array{Float64, 2} or Array{Float64, 1}`: Single univariate quantitative trait of N measurements (dimension: N*1)
 - `G::Array{Float64, 2}`: Matrix of genotype probabilities at p tested markers (dimension: N*p)
 - `K::Array{Float64, 2}`: Genetic relatedness matrix of the N subjects (dimension:N*N)
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -178,32 +178,20 @@ function shuffleVector(rng::AbstractRNG, x::Vector{Float64}, nshuffle::Int64;
     return xx
 end
 
-## Compare two arrays and return the number of elements with the same indices of each array and are match
-function compareValues(x_true::Array{Float64,1}, x::Array{Float64,1}, tolerance::Float64, threshold::Float64)
-    if size(x_true) != size(x)
-        throw(error("Dimention Mismatch! Must compare two arrays of same length!"))
-    end
+function p2lod(pval::Float64, df::Int64)
+    
+    lrs = invlogcdf(Chisq(df), log(1-pval))
+    lod = lrs/(2*log(10))
+    
+    return lod
 
-    passes = falses(size(x_true))
-    t_passes = falses(0)
-    for i in 1:size(x_true)[1]
-        e = abs(x[i]-x_true[i])
-        if e <= tolerance
-            passes[i] = true
-        end
+end
 
-        if x[i] >= threshold
-            if e <= tolerance
-                push!(t_passes, true)
-            else
-                push!(t_passes,false)
-            end
-        end
-
-    end
-    # pass_rate = sum(passes) / size(x_true)[1]
-    # pass_rate = sum(t_passes) / size(t_passes)[1]
-
-    return (sum(passes), size(t_passes)[1], sum(t_passes))
-
+function lod2p(lod::Float64, df::Int64)
+    
+    lrs = lod*2*log(10);
+    pval = 1-cdf(Chisq(df), lrs)
+    
+    return pval
+    
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -190,7 +190,7 @@ end
 function lod2p(lod::Float64, df::Int64)
     
     lrs = lod*2*log(10);
-    pval = 1-cdf(Chisq(df), lrs)
+    pval = ccdf(Chisq(df), lrs)
     
     return pval
     

--- a/test/bulkscan_test.jl
+++ b/test/bulkscan_test.jl
@@ -175,6 +175,13 @@ test_bulkscan_general = quote
 
     @test sum((test_bulkscan.L .- test_bulkscan_alt_grid.L).^2) <= 1e-7;
 
+    # test P-vals output:
+    test_Pvals = BulkLMM.bulkscan(stand_pheno, stand_geno, kinship;
+                                  method = "alt-grid", 
+                                  h2_grid = grid_list, 
+                                  prior_variance = 1.0, prior_sample_size = 0.1,
+                                  output_pvals = true);
+    @test sum((lod2p.(test_bulkscan.L, 1) .- test_Pvals.Pvals_mat).^2) <= 1e-7;
 
 end;
 

--- a/test/scan_covar_test.jl
+++ b/test/scan_covar_test.jl
@@ -36,4 +36,13 @@ println("Scan with covariates functions test (SVD2): ",
 @test mean(abs.(test_scan_covar.lod .- test_grid_covar_svd[:, 2])) <= tol
 )
 
+test_scan_covar_pvals = scan(pheno_y, geno, pseudo_covars, kinship; output_pvals = true);
+println("Scan with covariates functions test (p-vals output): ", 
+@test mean(abs.(lod2p.(test_scan_covar.lod, 1) .- test_scan_covar_pvals.pvals)) <= tol
+)
+
+test_scan_covar_vec = scan(pheno[:, pheno_id], geno, pseudo_covars, kinship);
+println("Scan with covariates functions test (vector trait input): ", 
+@test mean(abs.(test_scan_covar.lod .- test_scan_covar_vec.lod)) <= tol
+)
 

--- a/test/util_test.jl
+++ b/test/util_test.jl
@@ -297,40 +297,6 @@ tests_shuffleVector = quote
     testHelper(test3_shuffleVector);
 end;
 
-##########################################################################################################
-## TEST: compareValues()
-##########################################################################################################
-
-### Test1: check if dimensions match
-
-test1_compareValues = quote 
-    b_true = convert(Array{Float64, 1}, zeros(rand(collect(1:5))));
-    b_test = convert(Array{Float64, 1}, zeros(length(b_true)+1));
-
-    try 
-        BulkLMM.compareValues(b_true, b_test, 1e-3, 1e5)
-    catch e
-        @test typeof(e) == ErrorException
-    end
-end;
-
-### Test2: check if the results are as desired
-
-test2_compareValues = quote
-    b_true = convert(Array{Float64, 1}, zeros(rand(collect(2:5))));
-    b_test = copy(b_true);
-
-    b_test[length(b_true)] = 1.0
-    b_test[length(b_true)-1] = 2.0
-
-    @test BulkLMM.compareValues(b_test, b_true, 0.0, 1e5)[1] == length(b_true) - 2
-end;
-
-tests_compareValues = quote
-    testHelper(test1_compareValues);
-    testHelper(test2_compareValues);
-end;
-
 println("Utility functions test: ")
 @testset "Utility Functions Tests" begin
 
@@ -341,7 +307,6 @@ println("Utility functions test: ")
     eval(tests_rowDivide);
     eval(tests_rowMultiply);
     eval(tests_shuffleVector);
-    eval(tests_compareValues);
 
 end
 


### PR DESCRIPTION
- Updated documentation for `scan()` and `bulkscan()` to include the new changes.
- Updated README.md.