### PR TITLE
v1.2.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+## Version 1.2.2 (Feb 20, 2026)
+### Extended features:
+- Effect size reporting: 
+    - Added estimates of effect sizes and the associated standard errors in the outputs.
+    - The outputs of BulkLMM now contain the LOD scores, estimated effect sizes and standard errors, estimated variance components (in terms of heritabilities $h^2$), and p-values (optional if `output_pvals = true`).
+    - Example: Given the `out` as the structure of BulkLMM executions, effect sizes reflecting strengths of associations between trait-marker pairs are available as `out.B`, and the standard errors are as `out.SE`.
+    - By default, effect sizes and standard errors will always be returned.
+- More reliable estimation of variance component $h^2$ under grid-search based methods:
+    - For grid-search based BulkLMM methods(i.e., variance component estimation is discretized and done through grid-search for algorithmic efficiency), `bulkscan(..., method = "null-grid")` and `bulkscan(..., method = "alt-grid")`, instead of relying on a grid of arbitrary values or the user's choice, the package now supports the functionality to propose a grid based on exact values estimated from a smaller subset of traits, by specifying the proportion of the subset size in `subset_size_for_h2_scale`.
+    - This will add slight computational overhead but with more reliable estimates.
+    - By default, `subset_size_for_h2_scale = 0.0`—no dataset-specific grid will be proposed, but package estimates using a default grid of (0.0, 0.1, 0.2, ..., 0.9) or a grid defined by the user.
+
+
+### Bugs fixed:
+- There was a mistake in the formula for posterior calculation when using the single-trait scan function (`scan`). In this release that has been fixed and matches the correct version in multiple-trait scan function `bulkscan()`.
+
 ## Version 1.2.0 (Aug 17, 2023)
 - Help documentation added: to view the help documentation for functions `scan()`, and `bulkscan()`, type `?` in front of the functions.
 - New features:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BulkLMM"
 uuid = "b8d15608-0852-4141-ae38-222578e2ed7b"
 authors = ["Zifan Yu, Gregory Farage, Saunak Sen"]
-version = "1.2.0"
+version = "1.2.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"


### PR DESCRIPTION
## Version 1.2.2 (Feb 20, 2026)

This PR releases **BulkLMM v1.2.2**, adding effect size reporting, improving grid-search variance component estimation, and fixing a posterior calculation bug.

### Extended features
- **Effect size reporting (default output)**
  - Outputs now include **LOD scores, effect size estimates, standard errors, variance components (heritability $h^2$),** and **optional p-values** (enabled via `output_pvals = true`).
  - Effect sizes and SEs are available as `out.B` and `out.SE`.
  - **Effect sizes and SEs are returned by default**.

- **More reliable $h^2$ estimation for grid-search methods (`"null-grid"`, `"alt-grid"`)**
  - Added `subset_size_for_h2_scale` to **propose a dataset-informed $(h^2$ grid** using exact estimates from a subset of traits (slight overhead, improved reliability).
  - Default remains `subset_size_for_h2_scale = 0.0`, which uses the default grid (0.0, 0.1, ..., 0.9) or a user-defined grid.

### Bugs fixed
- Fixed an incorrect **posterior calculation** in the single-trait `scan()` function; it now matches the correct implementation in `bulkscan()`.

For more details, see [NEWS.md](https://github.com/senresearch/BulkLMM.jl/blob/main/NEWS.md).