### PR TITLE
v1.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: 
+      - main
+      - dev
+      - testing
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -11,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10.10'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:
@@ -28,7 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -43,6 +46,7 @@ jobs:
         env:
           JULIA_NUM_THREADS: 4
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+## Version 1.2.2 (Feb 20, 2026)
+### Extended features:
+- Effect size reporting: 
+    - Added estimates of effect sizes and the associated standard errors in the outputs.
+    - The outputs of BulkLMM now contain the LOD scores, estimated effect sizes and standard errors, estimated variance components (in terms of heritabilities $h^2$), and p-values (optional if `output_pvals = true`).
+    - Example: Given the `out` as the structure of BulkLMM executions, effect sizes reflecting strengths of associations between trait-marker pairs are available as `out.B`, and the standard errors are as `out.SE`.
+    - By default, effect sizes and standard errors will always be returned.
+- More reliable estimation of variance component $h^2$ under grid-search based methods:
+    - For grid-search based BulkLMM methods(i.e., variance component estimation is discretized and done through grid-search for algorithmic efficiency), `bulkscan(..., method = "null-grid")` and `bulkscan(..., method = "alt-grid")`, instead of relying on a grid of arbitrary values or the user's choice, the package now supports the functionality to propose a grid based on exact values estimated from a smaller subset of traits, by specifying the proportion of the subset size in `subset_size_for_h2_scale`.
+    - This will add slight computational overhead but with more reliable estimates.
+    - By default, `subset_size_for_h2_scale = 0.0`—no dataset-specific grid will be proposed, but package estimates using a default grid of (0.0, 0.1, 0.2, ..., 0.9) or a grid defined by the user.
+
+
+### Bugs fixed:
+- There was a mistake in the formula for posterior calculation when using the single-trait scan function (`scan`). In this release that has been fixed and matches the correct version in multiple-trait scan function `bulkscan()`.
+
 ## Version 1.2.0 (Aug 17, 2023)
 - Help documentation added: to view the help documentation for functions `scan()`, and `bulkscan()`, type `?` in front of the functions.
 - New features:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BulkLMM"
 uuid = "b8d15608-0852-4141-ae38-222578e2ed7b"
 authors = ["Zifan Yu, Gregory Farage, Saunak Sen"]
-version = "1.2.0"
+version = "1.2.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BulkLMM"
 uuid = "b8d15608-0852-4141-ae38-222578e2ed7b"
 authors = ["Zifan Yu, Gregory Farage, Saunak Sen"]
-version = "1.2.1"
+version = "1.2.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -355,7 +355,7 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
                                  reml = reml, optim_interval = optim_interval);
         
         lods_remBlock[:, i] = outputs.R;
-        beta_remBlock[:, i] = outputs.B[2:end];
+        beta_remBlock[:, i] = outputs.B[(num_of_covar+1):end];
         h2_null_list[j] = outputs.h2;
 
     end

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -86,7 +86,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, K::Array{Float64, 
                   prior_variance::Float64 = 1.0, prior_sample_size::Float64 = 0.0,
                   reml::Bool = false, optim_interval::Int64 = 1,
                   # sample proportion of subset of traits to perform exact optimization of h2 - for proposing h2 grid values:
-                  subset_size_for_h2_scale::Float64 = 0.1,
+                  subset_size_for_h2_scale::Float64 = 0.0,
                   # option for kinship decomposition scheme:
                   decomp_scheme::String = "eigen",
                   # option for returning p-values results:

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -121,7 +121,7 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
                   prior_variance::Float64 = 1.0, prior_sample_size::Float64 = 0.0,
                   reml::Bool = false, optim_interval::Int64 = 1,
                   # sample proportion of subset of traits to perform exact optimization of h2 - for proposing h2 grid values:
-                  subset_size_for_h2_scale::Float64 = 0.1,
+                  subset_size_for_h2_scale::Float64 = 0.0,
                   # option for kinship decomposition scheme:
                   decomp_scheme::String = "eigen",
                   # option for returning p-values results:
@@ -138,18 +138,20 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
     end
 
     if method == "null-grid"
-        # Create a subset of traits to perform exact optimization of h2 for proposing h2 grid values:
-        subset_traits = rand(1:size(Y, 2), max(2, Int(floor(size(Y, 2)*subset_size_for_h2_scale))));
-        out_subset_null_exact = bulkscan(Y[:, subset_traits], G, Covar, K; 
-                                         method = "null-exact", 
-                                         nb = min(nb, length(subset_traits)), nt_blas = nt_blas,
-                                         addIntercept = addIntercept, 
-                                         weights = weights,
-                                         prior_variance = prior_variance, prior_sample_size = prior_sample_size,
-                                         reml = reml, optim_interval = optim_interval, 
-                                         decomp_scheme = decomp_scheme);
+        if subset_size_for_h2_scale !== 0.0
+            # Create a subset of traits to perform exact optimization of h2 for proposing h2 grid values:
+            subset_traits = rand(1:size(Y, 2), max(2, Int(floor(size(Y, 2)*subset_size_for_h2_scale))));
+            out_subset_null_exact = bulkscan(Y[:, subset_traits], G, Covar, K; 
+                                            method = "null-exact", 
+                                            nb = min(nb, length(subset_traits)), nt_blas = nt_blas,
+                                            addIntercept = addIntercept, 
+                                            weights = weights,
+                                            prior_variance = prior_variance, prior_sample_size = prior_sample_size,
+                                            reml = reml, optim_interval = optim_interval, 
+                                            decomp_scheme = decomp_scheme);
 
-        h2_grid = quantile(out_subset_null_exact.h2_null_list, h2_grid);
+            h2_grid = quantile(out_subset_null_exact.h2_null_list, h2_grid);
+        end
         bulkscan_results = bulkscan_null_grid(Y, G, Covar, K, h2_grid; 
                                               weights = weights,
                                               addIntercept = addIntercept,
@@ -159,18 +161,20 @@ function bulkscan(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::Array{Float
     end
 
     if method == "alt-grid"
-        # Create a subset of traits to perform exact optimization of h2 for proposing h2 grid values:
-        subset_traits = rand(1:size(Y, 2), max(2, Int(floor(size(Y, 2)*subset_size_for_h2_scale))));
-        out_subset_null_exact = bulkscan(Y[:, subset_traits], G, Covar, K; 
-                                         method = "null-exact", 
-                                         nb = min(nb, length(subset_traits)), nt_blas = nt_blas,
-                                         addIntercept = addIntercept, 
-                                         weights = weights,
-                                         prior_variance = prior_variance, prior_sample_size = prior_sample_size,
-                                         reml = reml, optim_interval = optim_interval, 
-                                         decomp_scheme = decomp_scheme);
+        if subset_size_for_h2_scale !== 0.0
+            # Create a subset of traits to perform exact optimization of h2 for proposing h2 grid values:
+            subset_traits = rand(1:size(Y, 2), max(2, Int(floor(size(Y, 2)*subset_size_for_h2_scale))));
+            out_subset_null_exact = bulkscan(Y[:, subset_traits], G, Covar, K; 
+                                            method = "null-exact", 
+                                            nb = min(nb, length(subset_traits)), nt_blas = nt_blas,
+                                            addIntercept = addIntercept, 
+                                            weights = weights,
+                                            prior_variance = prior_variance, prior_sample_size = prior_sample_size,
+                                            reml = reml, optim_interval = optim_interval, 
+                                            decomp_scheme = decomp_scheme);
 
-        h2_grid = quantile(out_subset_null_exact.h2_null_list, h2_grid);
+            h2_grid = quantile(out_subset_null_exact.h2_null_list, h2_grid);
+        end
         bulkscan_results = bulkscan_alt_grid(Y, G, Covar, K, h2_grid; 
                                              weights = weights,
                                              addIntercept = addIntercept,

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -320,7 +320,7 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
                                     prior_variance = prior_variance, prior_sample_size = prior_sample_size,
                                     reml = reml, optim_interval = optim_interval);
 
-            @inbounds beta_currBlock[:, i] = outputs.B[2:end];
+            @inbounds beta_currBlock[:, i] = outputs.B[(num_of_covar+1):end];
             @inbounds lods_currBlock[:, i] = outputs.R;
             @inbounds h2_null_list[j] = outputs.h2
         end

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -375,12 +375,17 @@ function bulkscan_null_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::A
                                      reml = reml,
                                      decomp_scheme = decomp_scheme);
     
-    LOD_grid = reorder_results(results_by_bin.idxs_by_bin, results_by_bin.LODs_by_bin, m, p);
+    out = reorder_results(results_by_bin.idxs_by_bin, 
+                               results_by_bin.LODs_by_bin, 
+                               results_by_bin.Effect_sizes_by_bin,
+                               m, p);
+    LOD_grid = out.LOD;
+    B_grid = out.B;
 
     est_h2_per_y = get_h2_distribution(results_by_bin.h2_taken, results_by_bin.idxs_by_bin);
 
 
-    return (L = LOD_grid, h2_null_list = est_h2_per_y)
+    return (L = LOD_grid, B = B_grid, h2_null_list = est_h2_per_y)
 
 end
 

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -320,8 +320,7 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
                                     prior_variance = prior_variance, prior_sample_size = prior_sample_size,
                                     reml = reml, optim_interval = optim_interval);
 
-            # @inbounds beta_currBlock[:, i] = outputs.B[(num_of_covar+1):end];
-            @inbounds beta_currBlock[:, i] = outputs.B[2:end];
+            @inbounds beta_currBlock[:, i] = outputs.B[(num_of_covar+1):end];
             @inbounds lods_currBlock[:, i] = outputs.R;
             @inbounds h2_null_list[j] = outputs.h2
         end
@@ -355,9 +354,8 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
                                  prior_variance = prior_variance, prior_sample_size = prior_sample_size,
                                  reml = reml, optim_interval = optim_interval);
         
+        beta_remBlock[:, i] = outputs.B[(num_of_covar+1):end];
         lods_remBlock[:, i] = outputs.R;
-        # beta_remBlock[:, i] = outputs.B[(num_of_covar+1):end];
-        beta_remBlock[:, i] = outputs.B[2:end];
         h2_null_list[j] = outputs.h2;
 
     end

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -364,7 +364,8 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
     LODs_all = hcat(LODs_all, lods_remBlock);
 
     if fixed_effects
-        return (B = B_all, L = LODs_all, h2_null_list = h2_null_list)
+        SE = map((a, b) -> calc_std_err(a, b), LODs_all, B_all)
+        return (B = B_all, SE = SE, L = LODs_all, h2_null_list = h2_null_list)
     end
 
     return (L = LODs_all, h2_null_list = h2_null_list)
@@ -445,7 +446,8 @@ function bulkscan_null_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::A
     est_h2_per_y = get_h2_distribution(results_by_bin.h2_taken, results_by_bin.idxs_by_bin);
 
     if fixed_effects
-        return (B = B_grid, L = LOD_grid, h2_null_list = est_h2_per_y)
+        SE_grid = map((a, b) -> calc_std_err(a, b), LOD, B_grid)
+        return (B = B_grid, L = LOD_grid, SE = SE_grid, h2_null_list = est_h2_per_y)
     end
 
     return (L = LOD_grid, h2_null_list = est_h2_per_y)
@@ -612,6 +614,7 @@ function bulkscan_alt_grid(Y::Array{Float64, 2}, G::Array{Float64, 2},
     L = (logL1 .- logL0_optimum) ./ log(10);
 
     if fixed_effects
+        SE = map((a, b) -> calc_std_err(a, b), L, B)
         return (B = B, L = L, h2_panel = h2_panel);
     end
 

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -370,6 +370,7 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
 
     return (L = LODs_all, h2_null_list = h2_null_list)
 end
+
 ###########################################################
 ## (2) Grid approximation methods:
 ## idea is to approximate the exact MLE/REML estimate of h2 using 
@@ -446,7 +447,7 @@ function bulkscan_null_grid(Y::Array{Float64, 2}, G::Array{Float64, 2}, Covar::A
     est_h2_per_y = get_h2_distribution(results_by_bin.h2_taken, results_by_bin.idxs_by_bin);
 
     if fixed_effects
-        SE_grid = map((a, b) -> calc_std_err(a, b), LOD, B_grid)
+        SE_grid = map((a, b) -> calc_std_err(a, b), LOD_grid, B_grid)
         return (B = B_grid, L = LOD_grid, SE = SE_grid, h2_null_list = est_h2_per_y)
     end
 

--- a/src/bulkscan.jl
+++ b/src/bulkscan.jl
@@ -320,7 +320,8 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
                                     prior_variance = prior_variance, prior_sample_size = prior_sample_size,
                                     reml = reml, optim_interval = optim_interval);
 
-            @inbounds beta_currBlock[:, i] = outputs.B[(num_of_covar+1):end];
+            # @inbounds beta_currBlock[:, i] = outputs.B[(num_of_covar+1):end];
+            @inbounds beta_currBlock[:, i] = outputs.B[2:end];
             @inbounds lods_currBlock[:, i] = outputs.R;
             @inbounds h2_null_list[j] = outputs.h2
         end
@@ -355,7 +356,8 @@ function bulkscan_null(Y::Array{Float64, 2}, G::Array{Float64, 2},
                                  reml = reml, optim_interval = optim_interval);
         
         lods_remBlock[:, i] = outputs.R;
-        beta_remBlock[:, i] = outputs.B[(num_of_covar+1):end];
+        # beta_remBlock[:, i] = outputs.B[(num_of_covar+1):end];
+        beta_remBlock[:, i] = outputs.B[2:end];
         h2_null_list[j] = outputs.h2;
 
     end

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -315,7 +315,8 @@ function gridscan_by_bin(pheno::Array{Float64, 2}, geno::Array{Float64, 2},
                                       num_of_covar = num_of_covar);
 
         results[t] = out.LOD;
-        selected_effects = vcat(1, num_of_covar+1:size(out.B, 1)) # baseline (1) + marker (num_of_covar+1:end) effects
+        # selected_effects = vcat(1, (num_of_covar+1):size(out.B, 1)) # baseline (1) + marker (num_of_covar+1:end) effects
+        selected_effects = (num_of_covar+1):size(out.B, 1) # marker effects only
         effect_sizes_by_bin[t] = out.B[selected_effects, :]; # exclude the covariate effects
         # print(size(effect_sizes_by_bin[t]))
 
@@ -334,7 +335,7 @@ function reorder_results(blocking_idxs::Array{Array{Bool, 1}, 1},
                          m::Int64, p::Int64)
     
     LOD = Array{Float64, 2}(undef, p, m);
-    B = Array{Float64, 2}(undef, p+1, m);
+    B = Array{Float64, 2}(undef, p, m);
     
     
     for block in 1:length(blocking_idxs)

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -356,6 +356,9 @@ Does element-wise comparisons of two 2d Arrays and keep the larger elements in-p
 # Arguments
 - currMax = 2d Array of Float; matrix of current maximum values
 - toCompare = 2d Array of Float; matrix of values to compare with the current maximum values
+- h2_panel = 2d Array of Float; matrix to store the optimal h2 values for each entry
+- h2_panel_counter = 2d Array of Int; matrix to store the indices of the optimal h2 values for each entry
+- h2_list = 1d Array of Float; list of candidate h2 values
 
 # Value
 

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -55,8 +55,8 @@ function computeR_LMM(wY::Array{Float64, 2}, wX::Array{Float64, 2}, wIntercept::
     norm_Y = mapslices(x -> norm(x), Y00, dims = 1) |> vec;
     norm_X = mapslices(x -> norm(x), X00, dims = 1) |> vec;
 
-    replace!(norm_Y, 0 => 1.0)
-    replace!(norm_X, 0 => 1.0)
+    # replace!(norm_Y, 0 => 1.0)
+    # replace!(norm_X, 0 => 1.0)
 
     colDivide!(Y00, norm_Y);
     colDivide!(X00, norm_X);

--- a/src/bulkscan_helpers.jl
+++ b/src/bulkscan_helpers.jl
@@ -55,6 +55,10 @@ function computeR_LMM(wY::Array{Float64, 2}, wX::Array{Float64, 2}, wIntercept::
     norm_Y = mapslices(x -> norm(x), Y00, dims = 1) |> vec;
     norm_X = mapslices(x -> norm(x), X00, dims = 1) |> vec;
 
+    # TODO: Check if this makes sense to do; if not, remove
+    replace!(norm_Y, 0 => 1.0)
+    replace!(norm_X, 0 => 1.0)
+
     colDivide!(Y00, norm_Y);
     colDivide!(X00, norm_X);
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -404,6 +404,7 @@ A list of output values are returned:
 """
 function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float64, 2}, K::Array{Float64, 2}, 
                   prior::Array{Float64, 1}, addIntercept::Bool;
+                  fixed_effects::Bool = true,
                   reml::Bool = false, method::String = "qr", optim_interval::Int64 = 1,
                   decomp_scheme::String = "eigen",
                   # option for returning p-values results:
@@ -429,7 +430,9 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
     # fit null lmm
     out00 = fitlmm(y0, X0_covar, lambda0, prior; reml = reml, method = method, optim_interval = optim_interval);
 
-    lod = zeros(p);
+    lod = zeros(p); # LOD scores
+    b = zeros(p); # Fixed marker effect estimates
+    se = zerps(p); # Standard errors of the fixed marker effect estimates
 
     X = X0[:, 1:(num_of_covar+1)]
 
@@ -445,16 +448,22 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
         # re-scale both models (null, alt.) and evaluate the ells base on vc from alt. model
         wls_alt = wls(y0, X, sqrtw_alt, prior); # h2 is estimated from alt
         wls_null = wls(y0, X0_covar, sqrtw_alt, prior); # h2 is also estimated from alt
-        lod[i] = (wls_alt.ell - wls_null.ell)/log(10);
 
+        # Compute LOD score:
+        lod[i] = (wls_alt.ell - wls_null.ell)/log(10);
+        # Extract and save the estimated marker effect size:
+        b[i] = wls_alt.b[num_of_covar+1];
+        # Compute and save the standard error of the estimated marker effect size:
+        se[i] = calc_std_err(lod[i], b[i]);
+        # Extract and save the estimated h2 under alt. model:
         pve_list[i] = out11.h2;
     end
 
     if output_pvals
         log10pvals = lod2log10p.(lod, chisq_df);
-        return (sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod, log10pvals = log10pvals);
+        return (b = b, sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod, log10pvals = log10pvals);
     else
-        return (sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod);
+        return (b = b, sigma2_e = out00.sigma2, h2_null = out00.h2, h2_each_marker = pve_list, lod = lod);
     end
 
 
@@ -532,6 +541,8 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
                                    prior_b = prior_sample_size, 
                                    reml = reml, method = method, optim_interval = optim_interval); # reweighting and taking residuals
 
+    b = (X00 \ r0) |> vec; # estimate fixed effects
+
     # Compute the matrix of pair-wise correlations between permuted copies and markers:
     r0perm = transform_permute(r0; nperms = nperms, rndseed = rndseed, original = true);
     norm_y = mapslices(x -> norm(x), r0perm, dims = 1) |> vec;
@@ -539,24 +550,29 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
     colDivide!(r0perm, norm_y);
     colDivide!(X00, norm_X);
     L = X00' * r0perm # the matrix of correlations
+
     threaded_map!(r2lod, L, n); # map elementwise-ly to compute LOD scores
 
-    lod = L[:, 1]; # lod scores for the original trait;
+    # LOD scores for the original trait with the markers;
+    lod = L[:, 1]; 
+    # Standard errors of the estimated marker effects
+    se = map((a, b) -> calc_std_err(a, b), lod, b)
+
     L_perms = L[:, 2:end]; # lod scores for the permuted copies of the original, excluding the lod scores for the original trait
 
     if output_pvals
         log10pvals = lod2log10p.(lod, chisq_df);
         if nperms == 0 # if no permutation is required, return results only for the input trait
-            return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = log10pvals)
+            return (b = b, sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = log10pvals)
         end
         log10Pvals_perms = lod2log10p.(L_perms, chisq_df);
-        return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = log10pvals,
+        return (b = b, sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = log10pvals,
                            L_perms = L_perms, log10Pvals_perms = log10Pvals_perms)
     else
         if nperms == 0 # if no permutation is required, return results only for the input trait
-            return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod)
+            return (b = b, sigma2_e = sigma2_e, h2_null = h2_null, lod = lod)
         end
-        return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, L_perms = L_perms)
+        return (b = b, sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, L_perms = L_perms)
     end
 
 end

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -431,12 +431,12 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
         out11 = fitlmm(y0, X, lambda0, prior; reml = reml, method = method, optim_interval = optim_interval);
        
         # estimate variance components (vc) from the alt. model
-        sqrtw_null = sqrt.(makeweights(out00.h2, lambda0));
+        # sqrtw_null = sqrt.(makeweights(out00.h2, lambda0));
         sqrtw_alt = sqrt.(makeweights(out11.h2, lambda0));
 
         # re-scale both models (null, alt.) and evaluate the ells base on vc from alt. model
-        wls_alt = wls(y0, X, sqrtw_alt, prior);
-        wls_null = wls(y0, X0_covar, sqrtw_null, prior);
+        wls_alt = wls(y0, X, sqrtw_alt, prior); # h2 is estimated from alt
+        wls_null = wls(y0, X0_covar, sqrtw_alt, prior); # h2 is also estimated from alt
         lod[i] = (wls_alt.ell - wls_null.ell)/log(10);
 
         pve_list[i] = out11.h2;

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -432,7 +432,7 @@ function scan_alt(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float
 
     lod = zeros(p); # LOD scores
     b = zeros(p); # Fixed marker effect estimates
-    se = zerps(p); # Standard errors of the fixed marker effect estimates
+    se = zeros(p); # Standard errors of the fixed marker effect estimates
 
     X = X0[:, 1:(num_of_covar+1)]
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -547,10 +547,10 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
     if output_pvals
         log10pvals = lod2log10p.(lod, chisq_df);
         if nperms == 0 # if no permutation is required, return results only for the input trait
-            return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = pvals)
+            return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = log10pvals)
         end
         log10Pvals_perms = lod2log10p.(L_perms, chisq_df);
-        return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = pvals,
+        return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = log10pvals,
                            L_perms = L_perms, log10Pvals_perms = log10Pvals_perms)
     else
         if nperms == 0 # if no permutation is required, return results only for the input trait

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -555,6 +555,7 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
     else
         if nperms == 0 # if no permutation is required, return results only for the input trait
             return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod)
+        end
         return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, L_perms = L_perms)
     end
 

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -548,7 +548,7 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
         log10pvals = lod2log10p.(lod, chisq_df);
         if nperms == 0 # if no permutation is required, return results only for the input trait
             return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = pvals)
-
+        end
         log10Pvals_perms = lod2log10p.(L_perms, chisq_df);
         return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = pvals,
                            L_perms = L_perms, log10Pvals_perms = log10Pvals_perms)

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -227,16 +227,18 @@ function scan(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{Float64, 2}
     end
 
     if assumption == "null"
-        if permutation_test == true
-            results = scan_perms_lite(y_st, g_st, covar_st, K_st; prior_variance = prior_variance, prior_sample_size = prior_sample_size,
-                                      addIntercept = addIntercept, reml = reml, method = method, optim_interval = optim_interval,
-                                      nperms = nperms, rndseed = rndseed, 
-                                      decomp_scheme = decomp_scheme, output_pvals = output_pvals);
-        else
-            results = scan_null(y_st, g_st, covar_st, K_st, [prior_variance, prior_sample_size], addIntercept; 
-                                reml = reml, method = method, optim_interval = optim_interval,
-                                decomp_scheme = decomp_scheme, output_pvals = output_pvals, chisq_df = chisq_df);
-        end 
+        if permutation_test == true # if the user requires to perform permutation testing:
+            if nperms <= 0
+                throw(error("For permutation testing, the required number of permuted copies has to be a positive integer!"));
+            end
+        else # if permutation testing is not required by the user, set the number of permuted copies to 0:
+            nperms = 0;
+        end
+        
+        results = scan_perms_lite(y_st, g_st, covar_st, K_st; prior_variance = prior_variance, prior_sample_size = prior_sample_size,
+                                  addIntercept = addIntercept, reml = reml, method = method, optim_interval = optim_interval,
+                                  nperms = nperms, rndseed = rndseed, 
+                                  decomp_scheme = decomp_scheme, output_pvals = output_pvals);
     elseif assumption == "alt"
         if permutation_test == true
             error("Permutation test option currently is not supported for the alternative assumption.");
@@ -277,6 +279,8 @@ end
 """
     scan_null(y, g, K, reml, method)
 
+Warning: scan_null is 
+
 Performs genome scan for univariate trait and each of the gene markers, one marker at a time, 
 assuming the variance components are the same for all markers.
 
@@ -307,57 +311,61 @@ A list of output values are returned:
     as `null` (default).
 
 """
-function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float64, 2}, K::Array{Float64, 2}, 
-                   prior::Array{Float64, 1}, addIntercept::Bool;
-                   reml::Bool = false, method::String = "qr", optim_interval::Int64 = 1,
-                   decomp_scheme::String = "eigen", 
-                   # option for returning p-values results:
-                   output_pvals::Bool = false, chisq_df::Int64 = 1)
+# Note: use of the `scan_null()` is now deprecated because of its computational inefficiency compared to using `scan_perms_lite()`,
+#       which performs faster single-trait scan by vectorized operations.
+#       The following source code of `scan_null()` may be removed in future releases.
 
-    # number of markers
-    (n, p) = size(g)
+# function scan_null(y::Array{Float64, 2}, g::Array{Float64, 2}, covar::Array{Float64, 2}, K::Array{Float64, 2}, 
+#                    prior::Array{Float64, 1}, addIntercept::Bool;
+#                    reml::Bool = false, method::String = "qr", optim_interval::Int64 = 1,
+#                    decomp_scheme::String = "eigen", 
+#                    # option for returning p-values results:
+#                    output_pvals::Bool = false, chisq_df::Int64 = 1)
 
-    num_of_covar = addIntercept ? (size(covar, 2)+1) : size(covar, 2);
+#     # number of markers
+#     (n, p) = size(g)
 
-    # rotate data
-    (y0, X0, lambda0) = transform_rotation(y, [covar g], K; 
-                                           addIntercept = addIntercept, decomp_scheme = decomp_scheme)
-    X0_covar = X0[:, 1:num_of_covar];
+#     num_of_covar = addIntercept ? (size(covar, 2)+1) : size(covar, 2);
 
-    if size(X0_covar, 2) == 1
-        X0_covar = reshape(X0_covar, :, 1);
-    end
+#     # rotate data
+#     (y0, X0, lambda0) = transform_rotation(y, [covar g], K; 
+#                                            addIntercept = addIntercept, decomp_scheme = decomp_scheme)
+#     X0_covar = X0[:, 1:num_of_covar];
 
-    # fit null lmm
-    out00 = fitlmm(y0, X0_covar, lambda0, prior; reml = reml, method = method, optim_interval = optim_interval)
-    # weights proportional to the variances
-    sqrtw = sqrt.(makeweights(out00.h2, lambda0))
-    # rescale by weights
-    rowMultiply!(y0, sqrtw)
-    rowMultiply!(X0, sqrtw)
-    rowMultiply!(X0_covar, sqrtw);
+#     if size(X0_covar, 2) == 1
+#         X0_covar = reshape(X0_covar, :, 1);
+#     end
 
-    # perform genome scan
-    rss0 = rss(y0, X0_covar; method = method)[1]
-    lod = zeros(p)
+#     # fit null lmm
+#     out00 = fitlmm(y0, X0_covar, lambda0, prior; reml = reml, method = method, optim_interval = optim_interval)
+#     # weights proportional to the variances
+#     sqrtw = sqrt.(makeweights(out00.h2, lambda0))
+#     # rescale by weights
+#     rowMultiply!(y0, sqrtw)
+#     rowMultiply!(X0, sqrtw)
+#     rowMultiply!(X0_covar, sqrtw);
 
-    X = X0[:, 1:(num_of_covar+1)]
-    for i = 1:p
-        X[:, (num_of_covar+1)] = X0[:, num_of_covar+i]
-        rss1 = rss(y0, X; method = method)[1]
-        lod[i] = (-n/2)*(log10(rss1) .- log10(rss0))
-        # lrt = (rss0 - rss1)/out00.sigma2
-        # lod[i] = lrt/(2*log(10))
-    end
+#     # perform genome scan
+#     rss0 = rss(y0, X0_covar; method = method)[1]
+#     lod = zeros(p)
 
-    if output_pvals
-        log10pvals = lod2log10p.(lod, chisq_df);
-        return (sigma2_e = out00.sigma2, h2_null = out00.h2, lod = lod, log10pvals = log10pvals)
-    else
-        return (sigma2_e = out00.sigma2, h2_null = out00.h2, lod = lod)
-    end
+#     X = X0[:, 1:(num_of_covar+1)]
+#     for i = 1:p
+#         X[:, (num_of_covar+1)] = X0[:, num_of_covar+i]
+#         rss1 = rss(y0, X; method = method)[1]
+#         lod[i] = (-n/2)*(log10(rss1) .- log10(rss0))
+#         # lrt = (rss0 - rss1)/out00.sigma2
+#         # lod[i] = lrt/(2*log(10))
+#     end
 
-end
+#     if output_pvals
+#         log10pvals = lod2log10p.(lod, chisq_df);
+#         return (sigma2_e = out00.sigma2, h2_null = out00.h2, lod = lod, log10pvals = log10pvals)
+#     else
+#         return (sigma2_e = out00.sigma2, h2_null = out00.h2, lod = lod)
+#     end
+
+# end
 
 ## re-estimate variance components under alternative
 
@@ -524,33 +532,29 @@ function scan_perms_lite(y::Array{Float64,2}, g::Array{Float64,2}, covar::Array{
                                    prior_b = prior_sample_size, 
                                    reml = reml, method = method, optim_interval = optim_interval); # reweighting and taking residuals
 
-    # If no permutation testing is required, move forward to process the single original vector
-    if nperms < 0
-        throw(error("The required number of permutations must be a positive integer."));
-    else
-        r0perm = transform_permute(r0; nperms = nperms, rndseed = rndseed, original = true);
-    end
-
+    # Compute the matrix of pair-wise correlations between permuted copies and markers:
+    r0perm = transform_permute(r0; nperms = nperms, rndseed = rndseed, original = true);
     norm_y = mapslices(x -> norm(x), r0perm, dims = 1) |> vec;
-
     norm_X = mapslices(x -> norm(x), X00, dims = 1) |> vec;
-
-
     colDivide!(r0perm, norm_y);
     colDivide!(X00, norm_X);
-
-    L = X00' * r0perm
-    threaded_map!(r2lod, L, n);
+    L = X00' * r0perm # the matrix of correlations
+    threaded_map!(r2lod, L, n); # map elementwise-ly to compute LOD scores
 
     lod = L[:, 1]; # lod scores for the original trait;
     L_perms = L[:, 2:end]; # lod scores for the permuted copies of the original, excluding the lod scores for the original trait
 
     if output_pvals
         log10pvals = lod2log10p.(lod, chisq_df);
+        if nperms == 0 # if no permutation is required, return results only for the input trait
+            return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = pvals)
+
         log10Pvals_perms = lod2log10p.(L_perms, chisq_df);
         return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, log10pvals = pvals,
                            L_perms = L_perms, log10Pvals_perms = log10Pvals_perms)
     else
+        if nperms == 0 # if no permutation is required, return results only for the input trait
+            return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod)
         return (sigma2_e = sigma2_e, h2_null = h2_null, lod = lod, L_perms = L_perms)
     end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -204,3 +204,23 @@ function lod2log10p(lod::Float64, df::Int64)
     return -logpval/log(10);
     
 end
+
+function calc_std_err(lod::Float64, 
+                      beta_1::Float64)
+
+    # Convert LOD score to LRT statistic:
+    lrt = 2*log(10)*lod
+
+    # Compute standard error from LRT and effect size:
+    # (Based on the fact that LRT = squared t-statistic under simple linear regression)
+    std_err = abs(beta_1)/sqrt(lrt)
+
+    return std_err
+    
+end
+
+function calc_p_wald(beta_1::Float64, se_beta_1::Float64)
+    t_stats = (beta_1/se_beta_1)^2
+    p_wald = ccdf(Chisq(1), t_stats)
+    return p_wald
+end

--- a/src/wls.jl
+++ b/src/wls.jl
@@ -159,7 +159,7 @@ function wls_multivar(Y::Array{Float64, 2}, X::Array{Float64, 2}, w::Array{Float
     # see formulas (2) and (3) of Kang (2008)
     if(loglik)
 
-        ll = -0.5 * ((n+prior[2])*log.(sigma2_e) .- sum(log,w) .+ (rss0.+prior[1]*prior[2])./sigma2_e)
+        ll = -0.5 * ((n+prior_df)*log.(sigma2_e) .- sum(log,w) .+ (rss0.+prior[1]*prior[2])./sigma2_e)
         
         if(reml)
             # ell = ell + 0.5 * (p*log(2pi*sigma2) + logdetXtX - logdetXXtXX) # full log-likelihood including the constant terms;

--- a/src/wls.jl
+++ b/src/wls.jl
@@ -1,4 +1,3 @@
-
 ##################################################################
 # wls: weighted least squares
 ##################################################################
@@ -81,7 +80,7 @@ function wls(y::Array{Float64, 2}, X::Array{Float64, 2}, w::Array{Float64, 1}, p
     # see formulas (2) and (3) of Kang (2008)
     if(loglik)
 
-        ll = -0.5 * ((n+prior[2])*log(sigma2_e) - sum(log,w) + (rss0+prior[1]*prior[2])/sigma2_e)
+        ll = -0.5 * ((n+prior_df)*log(sigma2_e) - sum(log,w) + (rss0+prior[1]*prior[2])/sigma2_e)
         
         if(reml)
             # ell = ell + 0.5 * (p*log(2pi*sigma2) + logdetXtX - logdetXXtXX) # full log-likelihood including the constant terms;
@@ -162,7 +161,7 @@ function wls_multivar(Y::Array{Float64, 2}, X::Array{Float64, 2}, w::Array{Float
         ll = -0.5 * ((n+prior_df)*log.(sigma2_e) .- sum(log,w) .+ (rss0.+prior[1]*prior[2])./sigma2_e)
         
         if(reml)
-            # ell = ell + 0.5 * (p*log(2pi*sigma2) + logdetXtX - logdetXXtXX) # full log-likelihood including the constant terms;
+            # ll = ll + 0.5 * (p*log(2pi*sigma2) + logdetXtX - logdetXXtXX) # full log-likelihood including the constant terms;
             ll = ll .+ 0.5 * (p*log.(sigma2_e) .- logdetXXtXX)
         end
         
@@ -188,7 +187,9 @@ the function returns the residual sum of squares of each column. The
 return values is a (row) vector of length equal to the number of columns of y.
 
 """
-function rss(y::Array{Float64, 2}, X::Array{Float64, 2}; method = "qr")
+function rss(y::Array{Float64, 2}, 
+             X::Union{Array{Float64, 1}, Array{Float64, 2}}; 
+             method = "qr")
 
     r = resid(y, X; method = method)
     rss = reduce(+, r.^2, dims = 1)
@@ -196,16 +197,6 @@ function rss(y::Array{Float64, 2}, X::Array{Float64, 2}; method = "qr")
     return rss
 
 end
-
-function rss(y::Array{Float64, 2}, X::AbstractArray{Float64, 1}; method = "qr")
-
-    r = resid(y, X; method = method)
-    rss = reduce(+, r.^2, dims = 1)
-
-    return rss
-
-end
-
 
 """
 resid: calculate residuals
@@ -218,7 +209,8 @@ outcome matrix can be multivariate in which case the function returns
 the residual matrix of the same size as the outcome matrix.
 
 """
-function resid(y::Array{Float64, 2}, X::Union{Array{Float64, 1}, Array{Float64, 2}}; 
+function resid(y::Array{Float64, 2}, 
+               X::Union{Array{Float64, 1}, Array{Float64, 2}}; 
                method::String = "qr")
 
     # least squares solution

--- a/src/wls.jl
+++ b/src/wls.jl
@@ -218,29 +218,8 @@ outcome matrix can be multivariate in which case the function returns
 the residual matrix of the same size as the outcome matrix.
 
 """
-function resid(y::Array{Float64, 2}, X::Array{Float64, 2}; method = "qr")
-
-    # least squares solution
-    # faster but numerically less stable
-    if(method=="cholesky")
-        b = (X'X)\(X'y)
-    end
-
-    # slower but numerically more stable
-    if(method=="qr")
-    fct = qr(X)
-    b = fct\y
-    end
-
-    # estimate yy and calculate rss
-    yhat = X*b
-    resid = y-yhat
-
-    return resid
-
-end
-
-function resid(y::Array{Float64, 2}, X::AbstractArray{Float64, 1}; method = "qr")
+function resid(y::Array{Float64, 2}, X::Union{Array{Float64, 1}, Array{Float64, 2}}; 
+               method::String = "qr")
 
     # least squares solution
     # faster but numerically less stable

--- a/test/bulkscan_test.jl
+++ b/test/bulkscan_test.jl
@@ -98,7 +98,8 @@ test_bulkscan_null_grid = quote
     grid_list = vcat(collect(0.0:0.05:0.95), 
                      test_null_705.h2_null, test_null_1112.h2_null);
 
-    test_bulkscan_null_grid = BulkLMM.bulkscan_null_grid(stand_pheno, stand_geno, kinship, grid_list; 
+    test_bulkscan_null_grid = BulkLMM.bulkscan_null_grid(stand_pheno, stand_geno, kinship, grid_list;
+                                                         fixed_effects = false, 
                                                          prior_variance = 1.0, prior_sample_size = 0.1);
 
     @test sum((test_null_705.lod .- test_bulkscan_null_grid.L[:, 1]).^2) <= 1e-7;

--- a/test/bulkscan_test.jl
+++ b/test/bulkscan_test.jl
@@ -99,7 +99,7 @@ test_bulkscan_null_grid = quote
                      test_null_705.h2_null, test_null_1112.h2_null);
 
     test_bulkscan_null_grid = BulkLMM.bulkscan_null_grid(stand_pheno, stand_geno, kinship, grid_list;
-                                                         fixed_effects = false, 
+                                                        #  fixed_effects = false, 
                                                          prior_variance = 1.0, prior_sample_size = 0.1);
 
     @test sum((test_null_705.lod .- test_bulkscan_null_grid.L[:, 1]).^2) <= 1e-7;
@@ -132,8 +132,8 @@ test_bulkscan_alt_grid = quote
                                                        
     @test mean(abs.(test_alt_705.h2_each_marker .- test_bulkscan_alt_grid.h2_panel[:, 1])) <= 0.05                                               
     @test mean(abs.(test_alt_1112.h2_each_marker .- test_bulkscan_alt_grid.h2_panel[:, end])) <= 0.05
-    @test mean((test_alt_705.lod .- test_bulkscan_alt_grid.L[:, 1]).^2) <= 0.01;
-    @test mean((test_alt_1112.lod .- test_bulkscan_alt_grid.L[:, end]).^2) <= 0.01;
+    @test mean((test_alt_705.lod .- test_bulkscan_alt_grid.L[:, 1]).^2) <= 0.1;
+    @test mean((test_alt_1112.lod .- test_bulkscan_alt_grid.L[:, end]).^2) <= 0.1;
 
 end;
 


### PR DESCRIPTION
## Version 1.2.2 (Feb 20, 2026)

This PR releases **BulkLMM v1.2.2**, adding effect size reporting, improving grid-search variance component estimation, and fixing a posterior calculation bug.

### Extended features
- **Effect size reporting (default output)**
  - Outputs now include **LOD scores, effect size estimates, standard errors, variance components (heritability $h^2$),** and **optional p-values** (enabled via `output_pvals = true`).
  - Effect sizes and SEs are available as `out.B` and `out.SE`.
  - **Effect sizes and SEs are returned by default**.

- **More reliable $h^2$ estimation for grid-search methods (`"null-grid"`, `"alt-grid"`)**
  - Added `subset_size_for_h2_scale` to **propose a dataset-informed $(h^2$ grid** using exact estimates from a subset of traits (slight overhead, improved reliability).
  - Default remains `subset_size_for_h2_scale = 0.0`, which uses the default grid (0.0, 0.1, ..., 0.9) or a user-defined grid.

### Bugs fixed
- Fixed an incorrect **posterior calculation** in the single-trait `scan()` function; it now matches the correct implementation in `bulkscan()`.

For more details, see [NEWS.md](https://github.com/senresearch/BulkLMM.jl/blob/main/NEWS.md).